### PR TITLE
(#63) Javadoc in project site including unwanted packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,10 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <excludePackageNames>org.llorllale.youtrack.api.jaxb,org.llorllale.youtrack.api.util</excludePackageNames>
+              <level>protected</level>
+            </configuration>
             <reportSets>
               <reportSet>
                 <reports>


### PR DESCRIPTION
(FIX) pom.xml: configured javadoc plugin in reporting section as
      indicated in
      http://maven.apache.org/guides/mini/guide-configuring-plugins.html#Using_the_reporting_Tag_VS_build_Tag

closes #63 