### PR TITLE
(#65) Broken links in project site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       -in release/codesigning.asc.enc -out release/codesigning.asc -d
     - gpg --fast-import release/codesigning.asc
     - mvn --settings release/mvnsettings.xml -P deploy -DskipTests=true clean deploy
-    - mvn -P site clean site
+    - mvn -P site clean compile site
     deploy:
       provider: pages
       skip_cleanup: true

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -56,7 +56,7 @@ limitations under the License.
   <body>
     <links>
       <item name="About" href="./index.html"/>
-      <item name="GitHub" href="https://github.com/llorllale/youtrack-api"/>
+      <item name="GitHub" href="http://github.com/llorllale/youtrack-api"/>
     </links>
 
     <menu name="Documentation">
@@ -65,8 +65,8 @@ limitations under the License.
     </menu>
 
     <menu name="Project">
-      <item name="Releases" href="https://github.com/llorllale/youtrack-api/releases"/>
-      <item name="Issue Tracking" href="https://github.com/llorllale/youtrack-api/issues"/>
+      <item name="Releases" href="http://github.com/llorllale/youtrack-api/releases"/>
+      <item name="Issue Tracking" href="http://github.com/llorllale/youtrack-api/issues"/>
       <item name="License" href="./license.html"/>
       <item name="Members" href="./team-list.html"/>
       <item name="CheckStyle Report" href="./checkstyle.html"/>


### PR DESCRIPTION
    (FIX) GitHub, Releases, Issue Tracking: the reflow maven skin is
          automatically subing https://github.com/llorllale/youtrack-api
          (same url for ${project.url} with "/" - specifying "http" as
          the url scheme and relying on redirection to HTTPS solved this
    (FIX) FindBugs Report: report was not being generated when building
          the site because FindBugs analyzes byte code and not source
          code - see https://stackoverflow.com/a/8569524/1623885.

closes #65 