### PR TITLE
(#66) 1241 errors in checkstyle report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,15 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
+            <configuration>
+              <configLocation>google_checks.xml</configLocation>
+              <encoding>UTF-8</encoding>
+              <consoleOutput>true</consoleOutput>
+              <failsOnError>true</failsOnError>
+              <linkXRef>false</linkXRef>
+              <violationSeverity>info</violationSeverity>
+              <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+            </configuration>
             <reportSets>
               <reportSet>
                 <reports>


### PR DESCRIPTION
(FIX) pom.xml: checkstyle plugin in reporting section for `site` was
      missing its configuration

closes #66 