### PR TITLE
(#105) Implement XmlIssue.equals() and XmlIssue.hashCode()

### DIFF
--- a/src/main/java/org/llorllale/youtrack/api/Issue.java
+++ b/src/main/java/org/llorllale/youtrack/api/Issue.java
@@ -28,6 +28,9 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
 /**
  * A {@link YouTrack} issue.
  * 
+ * <p>Two issues are equal if their {@link #project() projects} are both equal, and their 
+ * {@link #id() ids} are also equal.
+ * 
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.1.0
  */

--- a/src/main/java/org/llorllale/youtrack/api/Project.java
+++ b/src/main/java/org/llorllale/youtrack/api/Project.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 /**
  * A YouTrack project.
  * 
+ * <p>Two projects are equal only if both their {@link #id() ids} are equal.
+ * 
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.4.0
  */

--- a/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
@@ -31,6 +31,8 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.1.0
  */
+//equals and hashCode tip the method count to just over the max allowed (12) to the actual 14
+@SuppressWarnings("checkstyle:MethodCount")
 class XmlIssue implements Issue {
   private final Project project;
   private final Session session;

--- a/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
@@ -129,4 +129,19 @@ class XmlIssue implements Issue {
     this.fields().forEach(f -> spec.with(f, f.value()));
     return spec;
   }
+
+  @Override
+  public int hashCode() {
+    return this.id().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (!(object instanceof Issue)) {
+      return false;
+    }
+
+    final Issue other = (Issue) object;
+    return this.id().equals(other.id()) && this.project().equals(other.project());
+  }
 }

--- a/src/test/java/org/llorllale/youtrack/api/XmlIssueTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlIssueTest.java
@@ -18,11 +18,15 @@ package org.llorllale.youtrack.api;
 
 import java.time.Instant;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.llorllale.youtrack.api.Issues.IssueSpec;
 import org.llorllale.youtrack.api.mock.MockAssignedField;
+import org.llorllale.youtrack.api.mock.MockIssue;
 import org.llorllale.youtrack.api.mock.MockProject;
 import org.llorllale.youtrack.api.mock.http.MockSession;
 
@@ -124,6 +128,105 @@ public class XmlIssueTest {
     assertThat(
         issue.spec(),
         is(expected)
+    );
+  }
+
+  /**
+   * {@link XmlIssue#hashCode()} must be equal to it's ID's hashCode.
+   * 
+   * @since 1.0.0
+   */
+  @Test
+  public void testHashCode() {
+    assertThat(
+        new XmlIssue(new MockProject(), new MockSession(), xml).id().hashCode(),
+        is("HBR-63".hashCode())
+    );
+  }
+
+  /**
+   * Two issues are equal if both their IDs and projects are equal.
+   * 
+   * @since 1.0.0
+   */
+  @Test
+  public void equals() {
+    final Project project = new MockProject("PR-1", "name", "description");
+    assertEquals(
+        new XmlIssue(project, new MockSession(), xml),
+        new MockIssue(project, "HBR-63", null, null, null)
+    );
+  }
+
+  /**
+   * An {@link XmlIssue} cannot be equal to {@code null}.
+   * 
+   * @since 1.0.0
+   */
+  @Test
+  public void equalsNullIsFalse() {
+    assertFalse(
+        new XmlIssue(new MockProject(), new MockSession(), xml).equals(null)
+    );
+  }
+
+  /**
+   * An {@link XmlIssue} cannot be equal to a type other than another {@link Issue}.
+   * 
+   * @since 1.0.0
+   */
+  @Test
+  public void equalsObjectIsFalse() {
+    assertFalse(
+        new XmlIssue(new MockProject(), new MockSession(), xml).equals(new Object())
+    );
+  }
+
+  /**
+   * An issue cannot be equal to an issue that belongs to another project, even if both their 
+   * ids are the same.
+   * 
+   * @since 1.0.0
+   */
+  @Test 
+  public void equalsWithDifferentProjectIsFalse() {
+    assertNotEquals( 
+        new XmlIssue(
+            new MockProject("PR-1", "name", "description"), 
+            new MockSession(), 
+            xml
+        ),
+        new MockIssue(
+            new MockProject("PR-2", "name", "description"), 
+            "HBR-63", 
+            null, 
+            null, 
+            null
+        )
+    );
+  }
+
+  /**
+   * An issue cannot be equal to another issue with a different ID, even if both belong to the 
+   * same project.
+   * 
+   * @since 1.0.0
+   */
+  @Test
+  public void equalsWithDifferentIssueIdIsFalse() {
+    assertNotEquals( 
+        new XmlIssue(
+            new MockProject("PR-1", "name", "description"), 
+            new MockSession(), 
+            xml
+        ),
+        new MockIssue(
+            new MockProject("PR-1", "name", "description"), 
+            "HBR-64", 
+            null, 
+            null, 
+            null
+        )
     );
   }
 

--- a/src/test/java/org/llorllale/youtrack/api/mock/MockIssue.java
+++ b/src/test/java/org/llorllale/youtrack/api/mock/MockIssue.java
@@ -132,24 +132,13 @@ public class MockIssue implements Issue {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
+  public boolean equals(Object object) {
+    if (!(object instanceof Issue)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final MockIssue other = (MockIssue) obj;
-    if (!Objects.equals(this.id, other.id)) {
-      return false;
-    }
-    if (!Objects.equals(this.project, other.project)) {
-      return false;
-    }
-    return true;
+
+    final Issue other = (Issue) object;
+    return this.id().equals(other.id()) && this.project().equals(other.project());
   }
 
   @Override


### PR DESCRIPTION
    (NEW) XmlIssue.equals() and hashCode()
    (NEW) Issue: clarification on equality in javadoc
    (FIX) Project: clarification on equality in javadoc
    (FIX) MockIssue: bug in equals() method

closes #105 