### PR TITLE
(#109) Some simple decorators are distorting the coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
   - if: type = pull_request
     script:
     - mvn -P release-profile -DskipTests=true clean install
-    - mvn -P integration-tests cobertura:cobertura-integration-test
+    - mvn -P integration-tests clean cobertura:cobertura-integration-test
     - bash <(curl -s https://codecov.io/bash)
   - if: type = push AND tag IS present
     script:

--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,20 @@
               <format>html</format>
               <format>xml</format>
             </formats>
+            <instrumentation>
+              <ignores>
+                <ignore>org.llorllale.youtrack.api.HttpRequestWithEntity</ignore>
+                <ignore>org.llorllale.youtrack.api.HttpRequestWithSession</ignore>
+                <ignore>org.llorllale.youtrack.api.StreamOf</ignore>
+                <ignore>org.llorllale.youtrack.api.StringAsDocument</ignore>
+              </ignores>
+              <excludes>
+                <exclude>org/llorllale/youtrack/api/HttpRequestWithEntity.class</exclude>
+                <exclude>org/llorllale/youtrack/api/HttpRequestWithSession.class</exclude>
+                <exclude>org/llorllale/youtrack/api/StreamOf.class</exclude>
+                <exclude>org/llorllale/youtrack/api/StringAsDocument.class</exclude>
+              </excludes>
+            </instrumentation>
           </configuration>
         </plugin>
         <plugin>

--- a/src/main/java/org/llorllale/youtrack/api/session/DefaultCookie.java
+++ b/src/main/java/org/llorllale/youtrack/api/session/DefaultCookie.java
@@ -16,15 +16,13 @@
 
 package org.llorllale.youtrack.api.session;
 
-import org.apache.http.Header;
-
 /**
  * Default implementation of {@link Cookie}.
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @since 1.0.0
  */
-public final class DefaultCookie implements Cookie {
+final class DefaultCookie implements Cookie {
   private final String name;
   private final String value;
 
@@ -35,20 +33,9 @@ public final class DefaultCookie implements Cookie {
    * @param value the cookie's value
    * @since 1.0.0
    */
-  public DefaultCookie(String name, String value) {
+  DefaultCookie(String name, String value) {
     this.name = name;
     this.value = value;
-  }
-
-  /**
-   * Constructs this {@link Cookie} base on the given {@link Header}.
-   * 
-   * @param header the header
-   * @see #DefaultCookie(java.lang.String, java.lang.String) 
-   * @since 1.0.0
-   */
-  DefaultCookie(Header header) {
-    this(header.getName(), header.getValue());
   }
 
   @Override


### PR DESCRIPTION
    pom.xml: excluded StreamOf, StringAsDocument, HttpRequestyWithEntity,
             and HttpRequestWithSession from coverage report
    .travis.yml: calling 'mvn clean' before running coverage analysis
             as per this comment: https://github.com/llorllale/youtrack-api/issues/109#issuecomment-352792799

closes #109 