### PR TITLE
(#126) UsernamePasswordLogin: NPE when login() multiple times

### DIFF
--- a/src/main/java/org/llorllale/youtrack/api/session/UsernamePasswordLogin.java
+++ b/src/main/java/org/llorllale/youtrack/api/session/UsernamePasswordLogin.java
@@ -17,7 +17,6 @@
 package org.llorllale.youtrack.api.session;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
@@ -39,8 +38,8 @@ import org.apache.http.impl.client.HttpClients;
 public final class UsernamePasswordLogin implements Login {
   private final URL youtrackUrl;
   private final HttpClient httpClient;
-  private String username;
-  private char[] password;
+  private final String username;
+  private final char[] password;
 
   /**
    * Primary constructor.
@@ -83,16 +82,15 @@ public final class UsernamePasswordLogin implements Login {
   @Override
   public Session login() throws AuthenticationException, IOException {
     try {
-      final URI uri = new URIBuilder(
-          this.youtrackUrl.toString().concat("/user/login")
-      ).setParameter("login", this.username)
-          .setParameter("password", new String(this.password))
-          .build();
-      this.username = null;
-      this.password = null;
-  
-      final HttpPost post = new HttpPost(uri);
-      final HttpResponse response = this.httpClient.execute(post);
+      final HttpResponse response = this.httpClient.execute(
+          new HttpPost(
+              new URIBuilder(
+                  this.youtrackUrl.toString().concat("/user/login")
+              ).setParameter("login", this.username)
+              .setParameter("password", new String(this.password))
+              .build()
+          )
+      );
   
       //@checkstyle todo there is more branching here
       if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {

--- a/src/test/java/org/llorllale/youtrack/api/session/UsernamePasswordLoginIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/session/UsernamePasswordLoginIT.java
@@ -43,4 +43,25 @@ public class UsernamePasswordLoginIT {
         is(not(empty()))
     );
   }
+
+  /**
+   * Fix #126: UsernamePasswordLogin: NPE when login() multiple times
+   * 
+   * @throws Exception 
+   * @since 1.0.0
+   */
+  @Test
+  public void multipleLogins() throws Exception {
+    final IntegrationTestsConfig config = new IntegrationTestsConfig();
+    final Login login = new UsernamePasswordLogin(
+        config.youtrackUrl(), 
+        config.youtrackUser(), 
+        config.youtrackPwd()
+    );
+    login.login();
+    assertThat(
+        login.login().cookies(),
+        is(not(empty()))
+    );
+  }
 }


### PR DESCRIPTION
    (FIX) UsernamePasswordLogin.login() was erroneously resetting user/pass
              fields to null. This attributes are now declared final.

closes #126 