### PR TITLE
(#133) TimeTrackEntry.date does not consider difference between user and server timezones

### DIFF
--- a/src/main/java/org/llorllale/youtrack/api/IssueTimeTracking.java
+++ b/src/main/java/org/llorllale/youtrack/api/IssueTimeTracking.java
@@ -19,7 +19,6 @@ package org.llorllale.youtrack.api;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -174,7 +173,7 @@ public interface IssueTimeTracking {
           .append("<date>")
           .append(String.valueOf(
                       this.date.atStartOfDay()
-                          .atZone(ZoneId.systemDefault())
+                          .atZone(YouTrack.ZONE_ID)
                           .toInstant()
                           .toEpochMilli()
                   )

--- a/src/main/java/org/llorllale/youtrack/api/XmlTimeTrackEntry.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlTimeTrackEntry.java
@@ -19,7 +19,6 @@ package org.llorllale.youtrack.api;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Optional;
 
 /**
@@ -55,7 +54,7 @@ class XmlTimeTrackEntry implements TimeTrackEntry {
         Long.parseLong(
             this.xml.textOf("date").get()
         )
-    ).atZone(ZoneId.systemDefault())
+    ).atZone(YouTrack.ZONE_ID)
         .toLocalDate();
   }
 

--- a/src/main/java/org/llorllale/youtrack/api/YouTrack.java
+++ b/src/main/java/org/llorllale/youtrack/api/YouTrack.java
@@ -16,6 +16,8 @@
 
 package org.llorllale.youtrack.api;
 
+import java.time.ZoneId;
+
 /**
  * Entry point for the YouTrack API.
  * 
@@ -23,6 +25,13 @@ package org.llorllale.youtrack.api;
  * @since 0.4.0
  */
 public interface YouTrack {
+  /**
+   * All date/time fields in YouTrack's API are expressed relative to this ZoneId.
+   * 
+   * @since 1.0.0
+   */
+  ZoneId ZONE_ID = ZoneId.of("GMT+0");
+
   /**
    * Access to the {@link Project projects} API.
    * 

--- a/src/test/java/org/llorllale/youtrack/api/EntrySpecTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/EntrySpecTest.java
@@ -58,7 +58,7 @@ public class EntrySpecTest {
     assertThat(
         new EntrySpec(LocalDate.now(), Duration.ZERO).asXml().textOf("/workItem/date"),
         is(Optional.of(String.valueOf(
-            LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            LocalDate.now().atStartOfDay().atZone(YouTrack.ZONE_ID).toInstant().toEpochMilli()
         )))
     );
   }

--- a/src/test/java/org/llorllale/youtrack/api/XmlTimeTrackEntryTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlTimeTrackEntryTest.java
@@ -50,13 +50,16 @@ public class XmlTimeTrackEntryTest {
     );
   }
 
+  /**
+   * @see <a href="https://github.com/llorllale/youtrack-api/issues/133">#133</a>
+   */
   @Test
   public void testDate() {
     assertThat(
         new XmlTimeTrackEntry(issue(), xml).date(),
         is(
             Instant.ofEpochMilli(1480204800000L)
-                .atZone(ZoneId.systemDefault())
+                .atZone(YouTrack.ZONE_ID)
                 .toLocalDate()
         )
     );


### PR DESCRIPTION
    (NEW) YouTrack.ZONE_ID: a constant against which all unix times should
                be parsed
    (FIX) DefaultIssueTimeTracking: now correctly shifting the date given by
             the user to GMT+0 when creating an entry
    (FIX) XmlTimeTrackEntry: now correctly parsing the workitem's date
             with YouTrack.ZONE_ID

closes #133 