### PR TITLE
(#132) Host javadocs in javadoc.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![codecov](https://codecov.io/gh/llorllale/youtrack-api/branch/master/graph/badge.svg)](https://codecov.io/gh/llorllale/youtrack-api)
 [![Build Status](https://travis-ci.org/llorllale/youtrack-api.svg?branch=master)](https://travis-ci.org/llorllale/youtrack-api)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.llorllale/youtrack-api/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.llorllale/youtrack-api)
+[![Javadocs](http://javadoc.io/badge/org.llorllale/youtrack-api.svg?color=blue)](http://javadoc.io/doc/org.llorllale/youtrack-api)
 
 `youtrack-api` is a fluent, object-oriented Java API for [YouTrack](https://www.jetbrains.com/youtrack/). Visit the [project's site](https://llorllale.github.io/youtrack-api) for more info. It has just one dependency: Apache's [HttpClient](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient) version `4.5.x`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -174,20 +174,6 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <level>protected</level>
-            </configuration>
-            <reportSets>
-              <reportSet>
-                <reports>
-                  <report>javadoc</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
             <configuration>
               <configLocation>checkstyle.xml</configLocation>

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -10,7 +10,7 @@ $h3 About
 
 **Note:** the API is currently unstable as we approach our [first milestone](https://github.com/llorllale/youtrack-api/milestone/1).
 
-View the [usage](./usage.html) and the [javadoc](./apidocs/index.html) resources for additional details.
+View the [usage](./usage.html) and the [javadoc](http://javadoc.io/doc/org.llorllale/youtrack-api) resources for additional details.
 
 For bugs or enhancements, please use our [issue tracker](${project.url}/issues).
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -61,7 +61,7 @@ limitations under the License.
 
     <menu name="Documentation">
       <item name="Usage" href="./usage.html"/>
-      <item name="JavaDocs ${project.version}" href="./apidocs/index.html"/>
+      <item name="JavaDocs ${project.version}" href="http://javadoc.io/doc/org.llorllale/youtrack-api"/>
     </menu>
 
     <menu name="Project">


### PR DESCRIPTION
    README: now including javadoc.io badge
    pom.xml: now excluding javadoc from report generation in profile 'site'
    index.md.vm and site.xml: JavaDoc links now pointing to javadoc.io

closes #132 