### PR TITLE
(#138) TimeTrackEntry: description should not be optional

### DIFF
--- a/src/main/java/org/llorllale/youtrack/api/IssueTimeTracking.java
+++ b/src/main/java/org/llorllale/youtrack/api/IssueTimeTracking.java
@@ -79,7 +79,7 @@ public interface IssueTimeTracking {
      * 
      * @param date the date when the entry was worked
      * @param duration the duration for the work
-     * @param description description for the work (may be {@code null})
+     * @param description description for the work
      * @param type the work type (eg. "Development") (may be {@code null})
      * @since 0.4.0
      */
@@ -182,7 +182,7 @@ public interface IssueTimeTracking {
           .append(String.valueOf(this.duration.toMinutes()))
           .append("</duration>")
           .append("<description>")
-          .append(Optional.ofNullable(this.description).orElse(""))
+          .append(this.description)
           .append("</description>");
 
       Optional.ofNullable(this.type).ifPresent(t -> 
@@ -207,7 +207,7 @@ public interface IssueTimeTracking {
     public int hashCode() {
       return this.duration.hashCode() 
           ^ this.date.hashCode()
-          ^ Optional.ofNullable(this.description).hashCode()
+          ^ this.description.hashCode()
           ^ Optional.ofNullable(this.type).hashCode();
     }
 

--- a/src/main/java/org/llorllale/youtrack/api/TimeTrackEntry.java
+++ b/src/main/java/org/llorllale/youtrack/api/TimeTrackEntry.java
@@ -54,10 +54,10 @@ public interface TimeTrackEntry {
   /**
    * The item's description.
    * 
-   * @return the item's description (if any was entered)
+   * @return the item's description
    * @since 0.4.0
    */
-  Optional<String> description();
+  String description();
 
   /**
    * The entry's {@link TimeTrackEntryType type}.

--- a/src/main/java/org/llorllale/youtrack/api/XmlTimeTrackEntry.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlTimeTrackEntry.java
@@ -64,8 +64,8 @@ class XmlTimeTrackEntry implements TimeTrackEntry {
   }
 
   @Override
-  public Optional<String> description() {
-    return this.xml.textOf("description");
+  public String description() {
+    return this.xml.textOf("description").get();
   }
 
   @Override

--- a/src/test/java/org/llorllale/youtrack/api/XmlTimeTrackEntryTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlTimeTrackEntryTest.java
@@ -18,7 +18,6 @@ package org.llorllale.youtrack.api;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
 import static org.hamcrest.CoreMatchers.is;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -76,7 +75,7 @@ public class XmlTimeTrackEntryTest {
   @Test
   public void testDescription() {
     assertThat(
-        new XmlTimeTrackEntry(issue(), xml).description().get(),
+        new XmlTimeTrackEntry(issue(), xml).description(),
         is("first work item")
 );
   }


### PR DESCRIPTION
    (REF) TimeTrackEntry.description: now returns String instead of
              Optional<String>
    (REF) EntrySpec: no longer assuming that user provided 'null' value for
              description
    (REF) refactor: XmlTimeTrackEntry, XmlTimeTrackEntryTest

closes #138 