### PR TITLE
(#128) Non-final implementations

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -75,6 +75,18 @@
       <property name="onCommentFormat" value="@checkstyle.ON\: [\w\|]+"/>
     </module>
 
+    <!-- 
+      Disallow non-final non-abstract classes.
+      Inheritance is the strongest form of class coupling/dependency.
+      See http://rcardin.github.io/programming/oop/software-engineering/2017/04/10/dependency-dot.html.
+    -->
+    <module name="Regexp">
+      <property name="message" value="All non-abstract classes must be final."/>
+      <property name="illegalPattern" value="true"/>
+      <property name="format" value="^((?!final)(?!abstract).)*class"/>
+      <property name="ignoreComments" value="true"/>
+    </module>
+
     <!-- Annotations -->
     <module name="AnnotationLocation"/>
     <module name="AnnotationUseStyle"/>

--- a/src/main/java/org/llorllale/youtrack/api/BasicField.java
+++ b/src/main/java/org/llorllale/youtrack/api/BasicField.java
@@ -22,7 +22,7 @@ package org.llorllale.youtrack.api;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.8.0
  */
-class BasicField implements Field {
+final class BasicField implements Field {
   private final String name;
   private final Project project;
 

--- a/src/main/java/org/llorllale/youtrack/api/BasicFieldValue.java
+++ b/src/main/java/org/llorllale/youtrack/api/BasicFieldValue.java
@@ -22,7 +22,7 @@ package org.llorllale.youtrack.api;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.8.0
  */
-class BasicFieldValue implements FieldValue {
+final class BasicFieldValue implements FieldValue {
   private final String value;
   private final Field field;
 

--- a/src/main/java/org/llorllale/youtrack/api/DefaultComments.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultComments.java
@@ -35,7 +35,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.4.0
  */
-class DefaultComments implements Comments {
+final class DefaultComments implements Comments {
   private static final String BASE_PATH = "/issue/";
 
   private final Session session;

--- a/src/main/java/org/llorllale/youtrack/api/DefaultFields.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultFields.java
@@ -31,7 +31,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.8.0
  */
-class DefaultFields implements Fields {
+final class DefaultFields implements Fields {
   private final Session session;
   private final Project project;
   private final HttpClient httpClient;

--- a/src/main/java/org/llorllale/youtrack/api/DefaultIssueTimeTracking.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultIssueTimeTracking.java
@@ -39,7 +39,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.4.0
  */
-class DefaultIssueTimeTracking implements IssueTimeTracking {
+final class DefaultIssueTimeTracking implements IssueTimeTracking {
   private static final String PATH_TEMPLATE = "/issue/%s/timetracking/workitem";
   private final Session session;
   private final Issue issue;

--- a/src/main/java/org/llorllale/youtrack/api/DefaultIssues.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultIssues.java
@@ -36,7 +36,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.4.0
  */
-class DefaultIssues implements Issues {
+final class DefaultIssues implements Issues {
   private final Project project;
   private final Session session;
   private final HttpClient httpClient;

--- a/src/main/java/org/llorllale/youtrack/api/DefaultProjectTimeTracking.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultProjectTimeTracking.java
@@ -32,7 +32,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.8.0
  */
-class DefaultProjectTimeTracking implements ProjectTimeTracking {
+final class DefaultProjectTimeTracking implements ProjectTimeTracking {
   private static final String PATH_TEMPLATE = "/admin/project/%s/timetracking";
   private final Project project;
   private final Session session;

--- a/src/main/java/org/llorllale/youtrack/api/DefaultProjects.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultProjects.java
@@ -33,7 +33,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.4.0
  */
-class DefaultProjects implements Projects {
+final class DefaultProjects implements Projects {
   private final YouTrack youtrack;
   private final Session session;
   private final HttpClient httpClient;

--- a/src/main/java/org/llorllale/youtrack/api/DefaultUpdateIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultUpdateIssue.java
@@ -38,7 +38,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.9.0
  */
-class DefaultUpdateIssue implements UpdateIssue {
+final class DefaultUpdateIssue implements UpdateIssue {
   private static final String PATH_TEMPLATE = "/issue/%s";
   private final Issue issue;
   private final Session session;

--- a/src/main/java/org/llorllale/youtrack/api/XmlAssignedField.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlAssignedField.java
@@ -23,7 +23,7 @@ package org.llorllale.youtrack.api;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.8.0
  */
-class XmlAssignedField implements AssignedField {
+final class XmlAssignedField implements AssignedField {
   private final Field field;
   private final Issue issue;
   private final Xml xml;

--- a/src/main/java/org/llorllale/youtrack/api/XmlFieldValue.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlFieldValue.java
@@ -22,7 +22,7 @@ package org.llorllale.youtrack.api;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.8.0
  */
-class XmlFieldValue implements FieldValue {
+final class XmlFieldValue implements FieldValue {
   private final Xml xml;
   private final Field field;
 

--- a/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
@@ -32,7 +32,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  */
 //equals and hashCode tip the method count to just over the max allowed (12) to the actual 14
 @SuppressWarnings("checkstyle:MethodCount")
-class XmlIssue implements Issue {
+final class XmlIssue implements Issue {
   private final Project project;
   private final Session session;
   private final Xml xml;

--- a/src/main/java/org/llorllale/youtrack/api/XmlProject.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlProject.java
@@ -26,7 +26,7 @@ import org.llorllale.youtrack.api.session.Session;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.2.0
  */
-class XmlProject implements Project {
+final class XmlProject implements Project {
   private final YouTrack youtrack;
   private final Session session;
   private final Xml xml;

--- a/src/main/java/org/llorllale/youtrack/api/XmlProjectField.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlProjectField.java
@@ -32,7 +32,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.8.0
  */
-class XmlProjectField implements ProjectField {
+final class XmlProjectField implements ProjectField {
   private final Xml xml;
   private final Project project;
   private final Session session;

--- a/src/main/java/org/llorllale/youtrack/api/XmlTimeTrackEntry.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlTimeTrackEntry.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.3.0
  */
-class XmlTimeTrackEntry implements TimeTrackEntry {
+final class XmlTimeTrackEntry implements TimeTrackEntry {
   private final Issue issue;
   private final Xml xml;
 

--- a/src/main/java/org/llorllale/youtrack/api/XmlTimeTrackEntryType.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlTimeTrackEntryType.java
@@ -22,7 +22,7 @@ package org.llorllale.youtrack.api;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.8.0
  */
-class XmlTimeTrackEntryType implements TimeTrackEntryType {
+final class XmlTimeTrackEntryType implements TimeTrackEntryType {
   private final Xml xml;
 
   /**

--- a/src/main/java/org/llorllale/youtrack/api/XmlUser.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlUser.java
@@ -22,7 +22,7 @@ package org.llorllale.youtrack.api;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.5.0
  */
-class XmlUser implements User {
+final class XmlUser implements User {
   private final Xml xml;
 
   /**

--- a/src/main/java/org/llorllale/youtrack/api/XmlUsersOfIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlUsersOfIssue.java
@@ -27,7 +27,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.5.0
  */
-class XmlUsersOfIssue implements UsersOfIssue {
+final class XmlUsersOfIssue implements UsersOfIssue {
   private final Issue issue;
   private final Xml xml;
 

--- a/src/main/java/org/llorllale/youtrack/api/XmlUsersOfProject.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlUsersOfProject.java
@@ -32,7 +32,7 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.9.0
  */
-class XmlUsersOfProject implements UsersOfProject {
+final class XmlUsersOfProject implements UsersOfProject {
   private final Project project;
   private final Session session;
   private final Xml xml;

--- a/src/main/java/org/llorllale/youtrack/api/session/AuthenticationException.java
+++ b/src/main/java/org/llorllale/youtrack/api/session/AuthenticationException.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * @see Login
  * @since 0.1.0
  */
-public class AuthenticationException extends IOException {
+public final class AuthenticationException extends IOException {
   private static final long serialVersionUID = -6585053905710875326L;
   
   /**

--- a/src/main/java/org/llorllale/youtrack/api/session/DefaultSession.java
+++ b/src/main/java/org/llorllale/youtrack/api/session/DefaultSession.java
@@ -28,7 +28,7 @@ import java.util.List;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.1.0
  */
-class DefaultSession implements Session {
+final class DefaultSession implements Session {
   private final URL youtrackUrl;
   private final List<Cookie> cookies;
 

--- a/src/main/java/org/llorllale/youtrack/api/session/UnauthorizedException.java
+++ b/src/main/java/org/llorllale/youtrack/api/session/UnauthorizedException.java
@@ -26,7 +26,7 @@ import org.apache.http.HttpResponse;
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.1.0
  */
-public class UnauthorizedException extends IOException {
+public final class UnauthorizedException extends IOException {
   private static final long serialVersionUID = -2245180199390157205L;
 
   private final HttpResponse httpResponse;


### PR DESCRIPTION
    (NEW) New checkstyle rule prohibiting non-final non-abstract classes
    (FIX) These classes are now final:
          - AuthenticationException
          - BasicField
          - BasicFieldValue
          - DefaultComments
          - DefaultFields
          - DefaultIssueTimeTracking
          - DefaultIssues
          - DefaultProjectTimeTracking
          - DefaultProjects
          - DefaultSession
          - DefaultUpdateIssue
          - UnauthorizedException
          - XmlAssignedField
          - XmlFieldValue
          - XmlIssue
          - XmlProject
          - XmlProjectField
          - XmlTimeTrackEntry
          - XmlTimeTrackEntryType
          - XmlUser
          - XmlUsersOfIssue
          - XmlUsersOfProject

closes #128 