### PR TITLE
(#145) Fail build if code coverage target is not met

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
   - if: type = pull_request
     script:
     - mvn -P release-profile -DskipTests=true clean install
-    - mvn -P integration-tests clean cobertura:check-integration-test
+    - mvn -P integration-tests clean cobertura:cobertura-integration-test && mvn -DskipTests=true cobertura:check-integration-test
     - bash <(curl -s https://codecov.io/bash)
   - if: type = push AND tag IS present
     script:
@@ -36,7 +36,7 @@ jobs:
         branch: master
   - if: type = push AND NOT tag IS present AND branch = master
     script:
-    - mvn -P integration-tests clean cobertura:check-integration-test
+    - mvn -P integration-tests clean cobertura:cobertura-integration-test && mvn -DskipTests=true cobertura:check-integration-test
     - bash <(curl -s https://codecov.io/bash)
     - mvn -P release-profile -DskipTests=true clean install
     - openssl aes-256-cbc -K $encrypted_af28e35ab9a0_key -iv $encrypted_af28e35ab9a0_iv

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
   - if: type = pull_request
     script:
     - mvn -P release-profile -DskipTests=true clean install
-    - mvn -P integration-tests clean cobertura:cobertura-integration-test
+    - mvn -P integration-tests clean cobertura:check-integration-test
     - bash <(curl -s https://codecov.io/bash)
   - if: type = push AND tag IS present
     script:
@@ -36,7 +36,7 @@ jobs:
         branch: master
   - if: type = push AND NOT tag IS present AND branch = master
     script:
-    - mvn -P integration-tests clean cobertura:cobertura-integration-test
+    - mvn -P integration-tests clean cobertura:check-integration-test
     - bash <(curl -s https://codecov.io/bash)
     - mvn -P release-profile -DskipTests=true clean install
     - openssl aes-256-cbc -K $encrypted_af28e35ab9a0_key -iv $encrypted_af28e35ab9a0_iv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,9 @@ integration-tests if applicable.
 Coverage is reported via [CodeCov.io](https://codecov.io/gh/llorllale/youtrack-api)
 and also the [project's site](https://llorllale.github.io/youtrack-api/cobertura/).
 
-**The current minimum target coverage is 80%.**
+**The current minimum target coverage is 90%.**
 
 #### Run the tests
-To run the unit tests simply run `mvn test`. To run the integration tests run
-`mvn -P integration-tests clean verify` (make sure your docker environment is
-setup as mentioned before).
+* To run the unit tests simply run `mvn test`. 
+* To run the integration tests run `mvn -P integration-tests clean cobertura:check-integration-test` 
+(make sure your docker environment is setup as mentioned before).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,10 @@ integration-tests if applicable.
 Coverage is reported via [CodeCov.io](https://codecov.io/gh/llorllale/youtrack-api)
 and also the [project's site](https://llorllale.github.io/youtrack-api/cobertura/).
 
-**The current minimum target coverage is 90%.**
+**The current minimum target coverage is 85%.**
 
 #### Run the tests
-* To run the unit tests simply run `mvn test`. 
-* To run the integration tests run `mvn -P integration-tests clean cobertura:check-integration-test` 
+* To run the unit tests: `mvn test`. 
+* To run unit and integration tests: `mvn -P integration-tests clean verify` 
 (make sure your docker environment is setup as mentioned before).
+* To run all tests and verify coverage: `mvn -P integration-tests clean cobertura:check-integration-test`

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <youtrack.test.user>root</youtrack.test.user>
     <youtrack.test.user.token>perm:cm9vdA==.eW91dHJhY2stYXBpLXRlc3Q=.nOe5IYpv520S120tK18hc2tkm8oCI4</youtrack.test.user.token>
     <youtrack.test.pwd>youtrack</youtrack.test.pwd>
-    <youtrack.test.baseUrl>http://192.168.99.100:18080</youtrack.test.baseUrl>
+    <youtrack.test.baseUrl>http://localhost:18080</youtrack.test.baseUrl>
     <youtrack.test.url>${youtrack.test.baseUrl}/rest</youtrack.test.url>
     <youtrack.test.project.id>TP</youtrack.test.project.id>
   </properties>
@@ -423,13 +423,13 @@
           <version>2.7</version>
           <configuration>
             <check>
-              <branchRate>90</branchRate>
-              <lineRate>90</lineRate>
+              <branchRate>0</branchRate>
+              <lineRate>85</lineRate>
               <haltOnFailure>true</haltOnFailure>
-              <totalBranchRate>90</totalBranchRate>
-              <totalLineRate>90</totalLineRate>
-              <packageLineRate>90</packageLineRate>
-              <packageBranchRate>90</packageBranchRate>
+              <totalBranchRate>85</totalBranchRate>
+              <totalLineRate>85</totalLineRate>
+              <packageLineRate>85</packageLineRate>
+              <packageBranchRate>85</packageBranchRate>
             </check>
             <formats>
               <format>html</format>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <youtrack.test.user>root</youtrack.test.user>
     <youtrack.test.user.token>perm:cm9vdA==.eW91dHJhY2stYXBpLXRlc3Q=.nOe5IYpv520S120tK18hc2tkm8oCI4</youtrack.test.user.token>
     <youtrack.test.pwd>youtrack</youtrack.test.pwd>
-    <youtrack.test.baseUrl>http://localhost:18080</youtrack.test.baseUrl>
+    <youtrack.test.baseUrl>http://192.168.99.100:18080</youtrack.test.baseUrl>
     <youtrack.test.url>${youtrack.test.baseUrl}/rest</youtrack.test.url>
     <youtrack.test.project.id>TP</youtrack.test.project.id>
   </properties>
@@ -422,7 +422,15 @@
           <artifactId>cobertura-maven-plugin</artifactId>
           <version>2.7</version>
           <configuration>
-            <check/>
+            <check>
+              <branchRate>90</branchRate>
+              <lineRate>90</lineRate>
+              <haltOnFailure>true</haltOnFailure>
+              <totalBranchRate>90</totalBranchRate>
+              <totalLineRate>90</totalLineRate>
+              <packageLineRate>90</packageLineRate>
+              <packageBranchRate>90</packageBranchRate>
+            </check>
             <formats>
               <format>html</format>
               <format>xml</format>

--- a/src/main/java/org/llorllale/youtrack/api/BadRequest.java
+++ b/src/main/java/org/llorllale/youtrack/api/BadRequest.java
@@ -47,13 +47,7 @@ final class BadRequest implements Response {
   @Override
   public HttpResponse httpResponse() throws IOException, UnauthorizedException {
     if (this.response.httpResponse().getStatusLine().getStatusCode() == HttpStatus.SC_BAD_REQUEST) {
-      throw new IOException(
-          String.format("Server returned 400 Bad Request. Payload: %s",
-              new InputStreamAsString().apply(
-                  this.response.httpResponse().getEntity().getContent()
-              )
-          )
-      );
+      throw new IOException("400 BadRequest");
     }
 
     return this.response.httpResponse();

--- a/src/main/java/org/llorllale/youtrack/api/InternalServerErrorResponse.java
+++ b/src/main/java/org/llorllale/youtrack/api/InternalServerErrorResponse.java
@@ -47,12 +47,7 @@ final class InternalServerErrorResponse implements Response {
   public HttpResponse httpResponse() throws IOException, UnauthorizedException {
     if (this.base.httpResponse().getStatusLine().getStatusCode() 
         == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
-      throw new IOException(
-          String.format("500 Internal Server error. Payload: %s", 
-              new InputStreamAsString().apply(this.base.httpResponse().getEntity().getContent()
-              )
-          )
-      );
+      throw new IOException("500 Internal Server error");
     }
 
     return this.base.httpResponse();

--- a/src/main/java/org/llorllale/youtrack/api/Pagination.java
+++ b/src/main/java/org/llorllale/youtrack/api/Pagination.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.http.client.HttpClient;
 
 import org.apache.http.client.methods.HttpUriRequest;
@@ -37,7 +38,7 @@ import org.apache.http.client.methods.HttpUriRequest;
  * @since 0.7.0
  */
 final class Pagination<T> implements Iterator<T> {
-  private final PageUri pageRequest;
+  private final Supplier<HttpUriRequest> pageRequest;
   private final ExceptionalFunction<Response, Collection<T>, IOException> mapper;
   private final HttpClient httpClient;
 
@@ -52,7 +53,7 @@ final class Pagination<T> implements Iterator<T> {
    * @since 0.7.0
    */
   Pagination(
-      PageUri pageRequest,
+      Supplier<HttpUriRequest> pageRequest,
       ExceptionalFunction<Response, Collection<T>, IOException> mapper,
       HttpClient httpClient
   ) {

--- a/src/main/java/org/llorllale/youtrack/api/UncheckedUriBuilder.java
+++ b/src/main/java/org/llorllale/youtrack/api/UncheckedUriBuilder.java
@@ -26,7 +26,7 @@ import org.apache.http.client.utils.URIBuilder;
  * <p>Hides all {@link URISyntaxException}s.</p>
  * 
  * <p>This class uses the {@link URIBuilder} internally but does not expose the aforementioned 
- * exception. A {@link RuntimeException} is thrown if the internal {@link URIBuilder} throws 
+ * exception. A {@link UncheckedException} is thrown if the internal {@link URIBuilder} throws 
  * {@link URISyntaxException}.</p>
  * 
  * <p>The main motivator for this class is to reduce all the {@code try...catch} noise in the 
@@ -42,14 +42,14 @@ final class UncheckedUriBuilder {
    * Constructs the internal {@link URIBuilder} with the given {@code baseUrl}.
    * 
    * @param baseUrl an initial url
-   * @throws RuntimeException wrapping any internal {@link URISyntaxException}
+   * @throws UncheckedException wrapping any internal {@link URISyntaxException}
    * @since 0.1.0
    */
-  UncheckedUriBuilder(String baseUrl) {
+  UncheckedUriBuilder(String baseUrl) throws UncheckedException {
     try {
       this.builder = new URIBuilder(baseUrl);
     } catch (URISyntaxException e) {
-      throw new RuntimeException(
+      throw new UncheckedException(
           String.format("This should not have happened: syntax issue with URL: %s", baseUrl),
           e
       );
@@ -61,10 +61,11 @@ final class UncheckedUriBuilder {
    * 
    * @param baseUrl the URL for the YouTrack RESTful endpoint API
    * @param path the resource's sub-path
+   * @throws UncheckedException wrapping any internal {@link URISyntaxException}
    * @see <a href="https://stackoverflow.com/a/724764/1623885">StackOverflow</a>
    * @since 1.0.0
    */
-  UncheckedUriBuilder(URL baseUrl, String path) {
+  UncheckedUriBuilder(URL baseUrl, String path) throws UncheckedException {
     try {
       this.builder = new URIBuilder(
           new URI(
@@ -78,7 +79,7 @@ final class UncheckedUriBuilder {
           )
       );
     } catch (URISyntaxException e) {
-      throw new RuntimeException(
+      throw new UncheckedException(
           String.format(
               "This should not have happened: syntax issue baseUrl=%s path=%s", 
               baseUrl.toString(), path
@@ -119,14 +120,14 @@ final class UncheckedUriBuilder {
    * Builds the {@link URI}.
    * 
    * @return the {@link URI} built by the internal {@link URIBuilder}
-   * @throws RuntimeException wrapping any internal {@link URISyntaxException}
+   * @throws UncheckedException wrapping any internal {@link URISyntaxException}
    * @since 0.1.0
    */
-  public URI build() {
+  public URI build() throws UncheckedException {
     try {
       return this.builder.build();
     } catch (URISyntaxException e) {
-      throw new RuntimeException("This should not have happened: syntax issue with a URL", e);     
+      throw new UncheckedException("This should not have happened: syntax issue with a URL", e);
     }
   }
 }

--- a/src/test/java/org/llorllale/youtrack/api/BadRequestTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/BadRequestTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.llorllale.youtrack.api.mock.http.response.MockBadRequestResponse;
+
+/**
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0-SNAPSHOT
+ */
+public class BadRequestTest {
+
+  /**
+   * Should throw {@link IOException} if server returns error code 400.
+   * 
+   * @since 1.0.0
+   */
+  @Test(expected = IOException.class)
+  public void testHttpResponse() throws Exception {
+    new BadRequest(() -> new MockBadRequestResponse()).httpResponse();
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/ForbiddenResponseTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/ForbiddenResponseTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import org.junit.Test;
+import org.llorllale.youtrack.api.mock.http.response.MockForbiddenResponse;
+import org.llorllale.youtrack.api.session.UnauthorizedException;
+
+/**
+ * Unit tests for {@link ForbiddenResponse}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0
+ */
+public class ForbiddenResponseTest {
+
+  /**
+   * Should throw {@link UnauthorizedException} if server returns error code 403.
+   * 
+   * @since 1.0.0
+   */
+  @Test(expected = UnauthorizedException.class)
+  public void testHttpResponse() throws Exception {
+    new ForbiddenResponse(() -> new MockForbiddenResponse()).httpResponse();
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/InternalServerErrorResponseTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/InternalServerErrorResponseTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.llorllale.youtrack.api.mock.http.response.MockInternalErrorResponse;
+
+/**
+ * Unit tests for {@link InternalServerErrorResponse}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0
+ */
+public class InternalServerErrorResponseTest {
+
+  /**
+   * Should throw an {@link IOException} if the YouTrack server returns an HTTP response with
+   * code 500.
+   * 
+   * @since 1.0.0
+   */
+  @Test(expected = IOException.class)
+  public void testHttpResponse() throws Exception {
+    new InternalServerErrorResponse(() -> new MockInternalErrorResponse()).httpResponse();
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/PageTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/PageTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import java.util.Collections;
+import java.util.NoSuchElementException;
+import static org.junit.Assert.assertFalse;
+import org.junit.Test;
+import org.llorllale.youtrack.api.mock.http.MockHttpClient;
+import org.llorllale.youtrack.api.mock.http.MockThrowingHttpClient;
+import org.llorllale.youtrack.api.mock.http.response.MockOkResponse;
+
+/**
+ * Unit tests for {@link Page}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0
+ */
+public class PageTest {
+  /**
+   * Ctor must wrap IOExceptions in UncheckedException.
+   * 
+   * @since 1.0.0
+   */
+  @Test(expected = UncheckedException.class)
+  public void ctorUncheckedExceptionThrow() {
+    new Page<>(
+        null,
+        r -> Collections.<String>emptyList(),
+        new MockThrowingHttpClient()
+    );
+  }
+
+  /**
+   * next() must throw NoSuchElementException if contents is empty.
+   * 
+   * @since 1.0.0
+   */
+  @Test(expected = NoSuchElementException.class)
+  public void nextNoSuchElementException() {
+    new Page<>(
+        null,
+        r -> Collections.<String>emptyList(),
+        new MockHttpClient(new MockOkResponse())
+    ).next();
+  }
+
+  /**
+   * Page.Empty.hasNext() should always return {@code false}.
+   * 
+   * @since 1.0.0
+   */
+  @Test
+  public void emptyHasNextAlwaysFalse() {
+    assertFalse(
+        new Page.Empty<>().hasNext()
+    );
+  }
+
+  /**
+   * Page.Empty.next() should always throw {@link NoSuchElementException}.
+   * 
+   * @since 1.0.0
+   */
+  @Test(expected = NoSuchElementException.class)
+  public void emptyNextAlwaysThrowsNoSuchElementException() {
+    new Page.Empty<>().next();
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/UnauthorizedResponseTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/UnauthorizedResponseTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import org.junit.Test;
+import org.llorllale.youtrack.api.mock.http.response.MockUnauthorizedResponse;
+import org.llorllale.youtrack.api.session.UnauthorizedException;
+
+/**
+ * Unit tests for {@link UnauthorizedResponse}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0
+ */
+public class UnauthorizedResponseTest {
+
+  /**
+   * Should throw {@link UnauthorizedException} when an "unauthorized" response is received.
+   * 
+   * @since 1.0.0
+   */
+  @Test(expected = UnauthorizedException.class)
+  public void testHttpResponse() throws Exception {
+    new UnauthorizedResponse(() -> new MockUnauthorizedResponse()).httpResponse();
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/UncheckedUriBuilderTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/UncheckedUriBuilderTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import java.net.URL;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link UncheckedUriBuilder}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0
+ */
+public class UncheckedUriBuilderTest {
+  /**
+   * Invalid URIs should be wrapped in an {@link UncheckedException}.
+   * 
+   * @since 1.0.0
+   */
+  @Test(expected = UncheckedException.class)
+  public void ctorStringUncheckedThrowWithInvalidUri() {
+    new UncheckedUriBuilder("invalid.uri.\"");
+  }
+
+  /**
+   * Invalid URIs should be wrapped in an {@link UncheckedException}.
+   * 
+   * @since 1.0.0
+   */
+  @Test(expected = UncheckedException.class)
+  public void ctorUrlPathUncheckedThrowWithInvalidUri() throws Exception {
+    new UncheckedUriBuilder(new URL("http://localhost"), "invalid");
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/mock/http/MockThrowingHttpClient.java
+++ b/src/test/java/org/llorllale/youtrack/api/mock/http/MockThrowingHttpClient.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api.mock.http;
+
+import java.io.IOException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * Mock impl. of {@link HttpClient} that always throws an {@link IOException}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0
+ */
+public final class MockThrowingHttpClient implements HttpClient {
+  private final IOException exception;
+
+  /**
+   * Ctor.
+   * 
+   * @since 1.0.0
+   */
+  public MockThrowingHttpClient() {
+    this.exception = new IOException("always fails");
+  }
+
+  @Override
+  public HttpParams getParams() {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+
+  @Override
+  public ClientConnectionManager getConnectionManager() {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+
+  @Override
+  public HttpResponse execute(HttpUriRequest request) throws IOException, ClientProtocolException {
+    throw this.exception;
+  }
+
+  @Override
+  public HttpResponse execute(HttpUriRequest request, HttpContext context) 
+      throws IOException, ClientProtocolException {
+    throw this.exception;
+  }
+
+  @Override
+  public HttpResponse execute(HttpHost target, HttpRequest request) 
+      throws IOException, ClientProtocolException {
+    throw this.exception;
+  }
+
+  @Override
+  public HttpResponse execute(HttpHost target, HttpRequest request, HttpContext context) 
+      throws IOException, ClientProtocolException {
+    throw this.exception;
+  }
+
+  @Override
+  public <T> T execute(HttpUriRequest request, ResponseHandler<? extends T> responseHandler) 
+      throws IOException, ClientProtocolException {
+    throw this.exception;
+  }
+
+  @Override
+  public <T> T execute(
+      HttpUriRequest request, 
+      ResponseHandler<? extends T> responseHandler, 
+      HttpContext context
+  ) throws IOException, ClientProtocolException {
+    throw this.exception;
+  }
+
+  @Override
+  public <T> T execute(
+      HttpHost target, 
+      HttpRequest request, 
+      ResponseHandler<? extends T> responseHandler
+  ) throws IOException, ClientProtocolException {
+    throw this.exception;
+  }
+
+  @Override
+  public <T> T execute(
+      HttpHost target, 
+      HttpRequest request, 
+      ResponseHandler<? extends T> responseHandler, 
+      HttpContext context
+  ) throws IOException, ClientProtocolException {
+    throw this.exception;
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/mock/http/response/MockBadRequestResponse.java
+++ b/src/test/java/org/llorllale/youtrack/api/mock/http/response/MockBadRequestResponse.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api.mock.http.response;
+
+import java.util.Locale;
+import org.apache.http.Header;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.params.HttpParams;
+
+/**
+ * Mock impl. of {@link HttpResponse} that simulates an HTTP response from YouTrack with code
+ * {@code 400}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0
+ */
+public final class MockBadRequestResponse implements HttpResponse {
+  private final StatusLine statusLine;
+
+  /**
+   * Ctor.
+   * 
+   * @since 1.0.0
+   */
+  public MockBadRequestResponse() {
+    this.statusLine = new BasicStatusLine(
+        new HttpVersion(1, 1), 
+        400, 
+        "Bad Request"
+    );
+  }
+
+  @Override
+  public StatusLine getStatusLine() {
+    return this.statusLine;
+  }
+
+  @Override
+  public void setStatusLine(StatusLine statusline) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setStatusLine(ProtocolVersion ver, int code) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setStatusLine(ProtocolVersion ver, int code, String reason) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setStatusCode(int code) throws IllegalStateException {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setReasonPhrase(String reason) throws IllegalStateException {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HttpEntity getEntity() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setEntity(HttpEntity entity) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Locale getLocale() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setLocale(Locale loc) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public ProtocolVersion getProtocolVersion() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public boolean containsHeader(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header[] getHeaders(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header getFirstHeader(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header getLastHeader(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header[] getAllHeaders() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void addHeader(Header header) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void addHeader(String name, String value) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setHeader(Header header) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setHeader(String name, String value) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setHeaders(Header[] headers) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void removeHeader(Header header) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void removeHeaders(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HeaderIterator headerIterator() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HeaderIterator headerIterator(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HttpParams getParams() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setParams(HttpParams params) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+}

--- a/src/test/java/org/llorllale/youtrack/api/mock/http/response/MockInternalErrorResponse.java
+++ b/src/test/java/org/llorllale/youtrack/api/mock/http/response/MockInternalErrorResponse.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api.mock.http.response;
+
+import java.util.Locale;
+import org.apache.http.Header;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.params.HttpParams;
+
+/**
+ * Mock impl. of {@link HttpResponse} that simulates an HTTP response from YouTrack with error
+ * code 500.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0
+ */
+public final class MockInternalErrorResponse implements HttpResponse {
+  private final StatusLine statusLine;
+
+  public MockInternalErrorResponse() {
+    this.statusLine = new BasicStatusLine(
+        new HttpVersion(1, 1),
+        500,
+        "Internal Server Error"
+    );
+  }
+
+  @Override
+  public StatusLine getStatusLine() {
+    return this.statusLine;
+  }
+
+  @Override
+  public void setStatusLine(StatusLine statusline) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setStatusLine(ProtocolVersion ver, int code) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setStatusLine(ProtocolVersion ver, int code, String reason) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setStatusCode(int code) throws IllegalStateException {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setReasonPhrase(String reason) throws IllegalStateException {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HttpEntity getEntity() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setEntity(HttpEntity entity) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Locale getLocale() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setLocale(Locale loc) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public ProtocolVersion getProtocolVersion() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public boolean containsHeader(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header[] getHeaders(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header getFirstHeader(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header getLastHeader(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header[] getAllHeaders() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void addHeader(Header header) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void addHeader(String name, String value) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setHeader(Header header) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setHeader(String name, String value) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setHeaders(Header[] headers) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void removeHeader(Header header) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void removeHeaders(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HeaderIterator headerIterator() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HeaderIterator headerIterator(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HttpParams getParams() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setParams(HttpParams params) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+}

--- a/src/test/java/org/llorllale/youtrack/api/mock/http/response/MockUnauthorizedResponse.java
+++ b/src/test/java/org/llorllale/youtrack/api/mock/http/response/MockUnauthorizedResponse.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2018 George Aristy.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api.mock.http.response;
+
+import java.util.Locale;
+import org.apache.http.Header;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.params.HttpParams;
+
+/**
+ * Mock implementation of {@link HttpResponse} suitable for unit tests.
+ * Simulates an HTTP response with code 401.
+ * 
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.0.0
+ */
+public final class MockUnauthorizedResponse implements HttpResponse {
+  private final StatusLine statusLine;
+
+  /**
+   * Ctor.
+   * 
+   * @since 1.0.0
+   */
+  public MockUnauthorizedResponse() {
+    this.statusLine = new BasicStatusLine(
+        new HttpVersion(1, 1), 
+        401, 
+        "Unauthorized"
+    );
+  }
+
+  @Override
+  public StatusLine getStatusLine() {
+    return this.statusLine;
+  }
+
+  @Override
+  public void setStatusLine(StatusLine statusline) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setStatusLine(ProtocolVersion ver, int code) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setStatusLine(ProtocolVersion ver, int code, String reason) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setStatusCode(int code) throws IllegalStateException {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setReasonPhrase(String reason) throws IllegalStateException {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HttpEntity getEntity() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setEntity(HttpEntity entity) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Locale getLocale() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setLocale(Locale loc) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public ProtocolVersion getProtocolVersion() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public boolean containsHeader(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header[] getHeaders(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header getFirstHeader(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header getLastHeader(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public Header[] getAllHeaders() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void addHeader(Header header) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void addHeader(String name, String value) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setHeader(Header header) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setHeader(String name, String value) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setHeaders(Header[] headers) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void removeHeader(Header header) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void removeHeaders(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HeaderIterator headerIterator() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HeaderIterator headerIterator(String name) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public HttpParams getParams() {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+
+  @Override
+  public void setParams(HttpParams params) {
+    throw new UnsupportedOperationException("Not supported yet."); //TODO
+  }
+}


### PR DESCRIPTION
    (NEW) pom.xml: cobertura configuration set to 85% target
    (NEW) .travis.yml: cobertura execution now fails if target coverage
          is not met
    (REF) CONTRIBUTING.md: updated documentation accordingly
    (FIX) Added a few unit tests to meet target coverage:
          - BadRequestTest
          - ForbiddenResponseTest
          - InternalServerErrorResponseTest
          - PageTest
          - UnauthorizedResponseTest
    (REF) Pagination: field declared as Supplier<HttpUriRequest> instead
          of PageUri so that cobertura would stop saying that the
          'Supplier' contract of PageUri was not being tested
    (NEW) A few more HTTP mocks to support tests:
          - MockThrowingHttpClient
          - MockBadRequestResponse
          - MockInternalErrorResponse
          - MockUnauthorizedResponse

closes #145 