### PR TITLE
(#169) Renamed Login.login() -> Login.session()

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here's a snippet of its usage:
 
 ```java
 final YouTrack youtrack = new DefaultYouTrack(
-    new PermanentToken("token").login()
+    new PermanentToken("token").session()
 );
 youtrack.projects().get("project_id").get()
     .issues()

--- a/src/main/java/org/llorllale/youtrack/api/CachedLogin.java
+++ b/src/main/java/org/llorllale/youtrack/api/CachedLogin.java
@@ -44,10 +44,10 @@ final class CachedLogin implements Login {
   }
 
   @Override
-  public Session login() throws AuthenticationException, IOException {
+  public Session session() throws AuthenticationException, IOException {
     synchronized (this.cache) {
       if (this.cache.isEmpty()) {
-        this.cache.add(this.origin.login());
+        this.cache.add(this.origin.session());
       }
     }
     return this.cache.get(0);

--- a/src/main/java/org/llorllale/youtrack/api/session/Anonymous.java
+++ b/src/main/java/org/llorllale/youtrack/api/session/Anonymous.java
@@ -27,7 +27,7 @@ import java.util.Collections;
  * </p>
  * 
  * <p>
- * Calling {@link #login() login()} on an {@code AnonymousLogin} is 
+ * Calling {@link #session() session()} on an {@code AnonymousLogin} is 
  * guaranteed to always succeed.
  * </p>
  * 
@@ -48,7 +48,7 @@ public final class Anonymous implements Login {
   }
   
   @Override
-  public Session login() throws AuthenticationException, IOException {
+  public Session session() throws AuthenticationException, IOException {
     return new DefaultSession(this.youtrackUrl, Collections.emptyList());
   }
 }

--- a/src/main/java/org/llorllale/youtrack/api/session/Login.java
+++ b/src/main/java/org/llorllale/youtrack/api/session/Login.java
@@ -20,24 +20,24 @@ import java.io.IOException;
 
 /**
  * <p>
- * Performs the {@link #login() login}.
+ * A YouTrack login.
  * </p>
  * 
  * <p>
  * YouTrack supports different authentication strategies (username/password, token, 
  * etc.), hence it's up to implementations to know what to do with 
- * {@link #login() login()}.
+ * {@link #session() session()}.
  * </p>
  * 
  * @author George Aristy (george.aristy@gmail.com)
  * @see UsernamePassword
- * @see AnonymousLogin
+ * @see Anonymous
+ * @see PermanentToken
  * @since 0.1.0
  */
 public interface Login {
   /**
-   * Performs the login function and returns a {@link Session} with sufficient
-   * state to allow further transactions with YouTrack.
+   * A {@link Session} for this {@link Login}.
    * 
    * @return a session object with state usable for further transactions.
    * @throws AuthenticationException if the login process fails due to invalid
@@ -45,5 +45,5 @@ public interface Login {
    * @throws IOException if the YouTrack endpoint is unreachable
    * @since 0.1.0
    */
-  Session login() throws AuthenticationException, IOException;
+  Session session() throws AuthenticationException, IOException;
 }

--- a/src/main/java/org/llorllale/youtrack/api/session/PermanentToken.java
+++ b/src/main/java/org/llorllale/youtrack/api/session/PermanentToken.java
@@ -43,7 +43,7 @@ public final class PermanentToken implements Login {
   }
 
   @Override
-  public Session login() throws AuthenticationException, IOException {
+  public Session session() throws AuthenticationException, IOException {
     return new DefaultSession(
         this.youtrackUrl, 
         new DefaultCookie(

--- a/src/main/java/org/llorllale/youtrack/api/session/UsernamePassword.java
+++ b/src/main/java/org/llorllale/youtrack/api/session/UsernamePassword.java
@@ -80,7 +80,7 @@ public final class UsernamePassword implements Login {
   }
   
   @Override
-  public Session login() throws AuthenticationException, IOException {
+  public Session session() throws AuthenticationException, IOException {
     try {
       final HttpResponse response = this.httpClient.execute(
           new HttpPost(

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -34,7 +34,7 @@ For bugs or enhancements, please use our [issue tracker](${project.url}/issues).
 $h4 Snippet
 
     final YouTrack youtrack = new DefaultYouTrack(
-        new PermanentToken("your_token").login()   //login
+        new PermanentToken("your_token").session()   //login
     );
     
     youtrack.projects()

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -21,7 +21,7 @@ that can be readily used by all other aspects of the API.
 
 The use of *permanent tokens* is **recommended**:
 
-    final Session session = new PermanentToken("your_token").login();
+    final Session session = new PermanentToken("your_token").session();
 
 A generic `IOException` may be thrown if the YouTrack server is unreachable,
 while an `AuthenticationException` - a more specific IOException - is thrown if

--- a/src/test/java/org/llorllale/youtrack/api/CachedLoginTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/CachedLoginTest.java
@@ -43,11 +43,11 @@ public final class CachedLoginTest {
     final Session session = new MockSession();
     final Login login = new CachedLogin(() -> session);
     assertThat(
-      login.login(),
+      login.session(),
       is(session)
     );
     assertThat(
-      login.login(),
+      login.session(),
       is(session)
     );
   }
@@ -60,7 +60,7 @@ public final class CachedLoginTest {
   public void propagatesAuthException() throws Exception {
     new CachedLogin(() -> {
       throw new AuthenticationException(null);
-    }).login();
+    }).session();
   }
 
   /**
@@ -71,6 +71,6 @@ public final class CachedLoginTest {
   public void propagatesIoException() throws Exception {
     new CachedLogin(() -> {
       throw new IOException();
-    }).login();
+    }).session();
   }
 }

--- a/src/test/java/org/llorllale/youtrack/api/DefaultCommentsIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultCommentsIT.java
@@ -49,7 +49,7 @@ public final class DefaultCommentsIT {
     session = new PermanentToken(
         config.youtrackUrl(), 
         config.youtrackUserToken()
-    ).login();
+    ).session();
 
     issue = new DefaultYouTrack(session)
         .projects()

--- a/src/test/java/org/llorllale/youtrack/api/DefaultFieldsIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultFieldsIT.java
@@ -45,7 +45,7 @@ public final class DefaultFieldsIT {
     final IntegrationTestsConfig config = new IntegrationTestsConfig();
     session = new PermanentToken(
       config.youtrackUrl(), config.youtrackUserToken()
-    ).login();
+    ).session();
     project = new DefaultYouTrack(session).projects().stream().findAny().get();
   }
 

--- a/src/test/java/org/llorllale/youtrack/api/DefaultIssueTimeTrackingIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultIssueTimeTrackingIT.java
@@ -50,7 +50,7 @@ public final class DefaultIssueTimeTrackingIT {
     session = new PermanentToken(
       config.youtrackUrl(),
       config.youtrackUserToken()
-    ).login();
+    ).session();
   }
 
   /**

--- a/src/test/java/org/llorllale/youtrack/api/DefaultIssuesIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultIssuesIT.java
@@ -47,7 +47,7 @@ public final class DefaultIssuesIT {
     session = new PermanentToken(
       config.youtrackUrl(), 
       config.youtrackUserToken()
-    ).login();
+    ).session();
     project = new DefaultYouTrack(session).projects().stream().findAny().get();
   }
 

--- a/src/test/java/org/llorllale/youtrack/api/DefaultProjectTimeTrackingIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultProjectTimeTrackingIT.java
@@ -45,7 +45,7 @@ public final class DefaultProjectTimeTrackingIT {
   @BeforeClass
   public static void setup() throws Exception {
     final IntegrationTestsConfig config = new IntegrationTestsConfig();
-    session = new PermanentToken(config.youtrackUrl(), config.youtrackUserToken()).login();
+    session = new PermanentToken(config.youtrackUrl(), config.youtrackUserToken()).session();
     project = new DefaultYouTrack(session).projects().stream().findAny().get();
   }
 

--- a/src/test/java/org/llorllale/youtrack/api/DefaultProjectsIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultProjectsIT.java
@@ -47,7 +47,7 @@ public final class DefaultProjectsIT {
     session = new PermanentToken(
       config.youtrackUrl(),
       config.youtrackUserToken()
-    ).login();
+    ).session();
   }
 
   /**

--- a/src/test/java/org/llorllale/youtrack/api/DefaultUpdateIssueIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultUpdateIssueIT.java
@@ -47,7 +47,7 @@ public final class DefaultUpdateIssueIT {
     session = new PermanentToken(
       config.youtrackUrl(),
       config.youtrackUserToken()
-    ).login();
+    ).session();
     issue = new DefaultYouTrack(session).projects().stream()
       .findAny()
       .get()

--- a/src/test/java/org/llorllale/youtrack/api/XmlCommentIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlCommentIT.java
@@ -47,7 +47,7 @@ public final class XmlCommentIT {
     session = new PermanentToken(
       config.youtrackUrl(),
       config.youtrackUserToken()
-    ).login();
+    ).session();
     issue = new DefaultYouTrack(session)
       .projects()
       .stream()

--- a/src/test/java/org/llorllale/youtrack/api/XmlUsersOfIssueIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlUsersOfIssueIT.java
@@ -49,7 +49,7 @@ public final class XmlUsersOfIssueIT {
     session = new PermanentToken(
       config.youtrackUrl(), 
       config.youtrackUserToken()
-    ).login();
+    ).session();
   }
 
   /**

--- a/src/test/java/org/llorllale/youtrack/api/XmlUsersOfProjectIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlUsersOfProjectIT.java
@@ -44,7 +44,7 @@ public final class XmlUsersOfProjectIT {
   @BeforeClass
   public static void setup() throws Exception {
     config = new IntegrationTestsConfig();
-    session = new PermanentToken(config.youtrackUrl(), config.youtrackUserToken()).login();
+    session = new PermanentToken(config.youtrackUrl(), config.youtrackUserToken()).session();
     project = new DefaultYouTrack(session).projects().stream().findAny().get();
   }
 

--- a/src/test/java/org/llorllale/youtrack/api/session/AnonymousTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/session/AnonymousTest.java
@@ -37,7 +37,7 @@ public final class AnonymousTest {
     assertNotNull(
       new Anonymous(
         new URL("http://some.url")
-      ).login()
+      ).session()
     );
   }
 }

--- a/src/test/java/org/llorllale/youtrack/api/session/PermanentTokenTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/session/PermanentTokenTest.java
@@ -41,7 +41,7 @@ public final class PermanentTokenTest {
       new PermanentToken(
         new URL("http://some.url"), 
         token
-      ).login()
+      ).session()
     );
   }
 
@@ -56,7 +56,7 @@ public final class PermanentTokenTest {
       new PermanentToken(
         new URL("http://some.url"), 
           token
-      ).login()
+      ).session()
         .cookies()
         .stream()
         .allMatch(

--- a/src/test/java/org/llorllale/youtrack/api/session/UsernamePasswordIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/session/UsernamePasswordIT.java
@@ -44,7 +44,7 @@ public final class UsernamePasswordIT {
         config.youtrackUrl(), 
         config.youtrackUser(), 
         config.youtrackPwd()
-      ).login()
+      ).session()
         .cookies(),
       is(not(empty()))
     );
@@ -63,9 +63,9 @@ public final class UsernamePasswordIT {
       config.youtrackUser(), 
       config.youtrackPwd()
     );
-    login.login();
+    login.session();
     assertThat(
-      login.login().cookies(),
+      login.session().cookies(),
       is(not(empty()))
     );
   }

--- a/src/test/java/org/llorllale/youtrack/api/session/UsernamePasswordTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/session/UsernamePasswordTest.java
@@ -52,7 +52,7 @@ public final class UsernamePasswordTest {
                     new BasicHeader("Set-Cookie", "123")
                 )
             )
-        ).login()
+        ).session()
     );
   }
 
@@ -70,7 +70,7 @@ public final class UsernamePasswordTest {
         new MockHttpClient(
             new MockForbiddenResponse()
         )
-    ).login();
+    ).session();
   }
 
   /**
@@ -98,7 +98,7 @@ public final class UsernamePasswordTest {
             )
           )
         )
-      ).login()
+      ).session()
         .cookies()
         .stream()
         .allMatch(c -> "Cookie".equals(c.name()))
@@ -130,7 +130,7 @@ public final class UsernamePasswordTest {
             )
           )
         )
-      ).login()
+      ).session()
         .cookies()
         .stream()
         .allMatch(


### PR DESCRIPTION
This PR:
* closes #169 
* Renames `Login.login()` -> `Login.session()`