### PR TITLE
(#71) Get all attachments for an Issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,14 +472,14 @@
               <ignores>
                 <ignore>org.llorllale.youtrack.api.HttpRequestWithEntity</ignore>
                 <ignore>org.llorllale.youtrack.api.HttpRequestWithSession</ignore>
-                <ignore>org.llorllale.youtrack.api.StreamOf</ignore>
                 <ignore>org.llorllale.youtrack.api.StringAsDocument</ignore>
+                <ignore>org.llorllale.youtrack.api.StreamEnvelope</ignore>
               </ignores>
               <excludes>
                 <exclude>org/llorllale/youtrack/api/HttpRequestWithEntity.class</exclude>
                 <exclude>org/llorllale/youtrack/api/HttpRequestWithSession.class</exclude>
-                <exclude>org/llorllale/youtrack/api/StreamOf.class</exclude>
                 <exclude>org/llorllale/youtrack/api/StringAsDocument.class</exclude>
+                <exclude>org/llorllale/youtrack/api/StreamEnvelope.class</exclude>
               </excludes>
             </instrumentation>
           </configuration>

--- a/src/main/java/org/llorllale/youtrack/api/Attachment.java
+++ b/src/main/java/org/llorllale/youtrack/api/Attachment.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import java.io.IOException;
+import org.llorllale.youtrack.api.session.Login;
+import org.llorllale.youtrack.api.session.UnauthorizedException;
+
+/**
+ * An attachment.
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.1.0
+ * @todo #71 Add an attribute to Attachment for its contents. This would return an
+ *  InputStream with the attachment's contents. Add another attribute for the
+ *  attachment's content-type.
+ */
+public interface Attachment {
+  /**
+   * This attachment's name.
+   * @return name of attachment
+   */
+  String name();
+
+  /**
+   * This attahment's creator.
+   * @return the creator
+   * @throws IOException if the server is unavailable
+   * @throws UnauthorizedException if the user's {@link Login} is not authorized to perform this
+   *     operation
+   */
+  User creator() throws IOException, UnauthorizedException;
+}

--- a/src/main/java/org/llorllale/youtrack/api/Attachments.java
+++ b/src/main/java/org/llorllale/youtrack/api/Attachments.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import java.util.stream.Stream;
+
+/**
+ * Attachments of an {@link Issue}.
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.1.0
+ * @todo #71 Implement Attachments interface. It is a stream (as anticipated in
+ *  #200), and will in the future support creation of attachments.
+ */
+public interface Attachments extends Stream<Attachment> {
+  
+}

--- a/src/main/java/org/llorllale/youtrack/api/Issue.java
+++ b/src/main/java/org/llorllale/youtrack/api/Issue.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
-
 import org.llorllale.youtrack.api.session.Login;
 import org.llorllale.youtrack.api.session.UnauthorizedException;
 

--- a/src/main/java/org/llorllale/youtrack/api/StreamEnvelope.java
+++ b/src/main/java/org/llorllale/youtrack/api/StreamEnvelope.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2017 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collector;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+/**
+ * Stream envelope.
+ * @author George Aristy (george.aristy@gmail.com)
+ * @param <T> This stream's type
+ * @since 1.1.0
+ */
+@SuppressWarnings("checkstyle:MethodCount")
+abstract class StreamEnvelope<T> implements Stream<T> {
+  private final Stream<T> stream;
+
+  /**
+   * Primary ctor.
+   * 
+   * @param stream the actual stream implementation 
+   * @since 1.0.0
+   */
+  protected StreamEnvelope(Stream<T> stream) {
+    this.stream = stream;
+  }
+
+  @Override
+  public final Stream<T> filter(Predicate<? super T> predicate) {
+    return this.stream.filter(predicate);
+  }
+
+  @Override
+  public final <R> Stream<R> map(Function<? super T, ? extends R> mapper) {
+    return this.stream.map(mapper);
+  }
+
+  @Override
+  public final IntStream mapToInt(ToIntFunction<? super T> mapper) {
+    return this.stream.mapToInt(mapper);
+  }
+
+  @Override
+  public final LongStream mapToLong(ToLongFunction<? super T> mapper) {
+    return this.stream.mapToLong(mapper);
+  }
+
+  @Override
+  public final DoubleStream mapToDouble(ToDoubleFunction<? super T> mapper) {
+    return this.stream.mapToDouble(mapper);
+  }
+
+  @Override
+  public final <R> Stream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
+    return this.stream.flatMap(mapper);
+  }
+
+  @Override
+  public final IntStream flatMapToInt(Function<? super T, ? extends IntStream> mapper) {
+    return this.stream.flatMapToInt(mapper);
+  }
+
+  @Override
+  public final LongStream flatMapToLong(Function<? super T, ? extends LongStream> mapper) {
+    return this.stream.flatMapToLong(mapper);
+  }
+
+  @Override
+  public final DoubleStream flatMapToDouble(Function<? super T, ? extends DoubleStream> mapper) {
+    return this.stream.flatMapToDouble(mapper);
+  }
+
+  @Override
+  public final Stream<T> distinct() {
+    return this.stream.distinct();
+  }
+
+  @Override
+  public final Stream<T> sorted() {
+    return this.stream.sorted();
+  }
+
+  @Override
+  public final Stream<T> sorted(Comparator<? super T> comparator) {
+    return this.stream.sorted(comparator);
+  }
+
+  @Override
+  public final Stream<T> peek(Consumer<? super T> action) {
+    return this.stream.peek(action);
+  }
+
+  @Override
+  public final Stream<T> limit(long maxSize) {
+    return this.stream.limit(maxSize);
+  }
+
+  @Override
+  public final Stream<T> skip(long n) {
+    return this.stream.skip(n);
+  }
+
+  @Override
+  public final void forEach(Consumer<? super T> action) {
+    this.stream.forEach(action);
+  }
+
+  @Override
+  public final void forEachOrdered(Consumer<? super T> action) {
+    this.stream.forEachOrdered(action);
+  }
+
+  @Override
+  public final Object[] toArray() {
+    return this.stream.toArray();
+  }
+
+  @Override
+  public final <A> A[] toArray(IntFunction<A[]> generator) {
+    return this.stream.toArray(generator);
+  }
+
+  @Override
+  public final T reduce(T identity, BinaryOperator<T> accumulator) {
+    return this.stream.reduce(identity, accumulator);
+  }
+
+  @Override
+  public final Optional<T> reduce(BinaryOperator<T> accumulator) {
+    return this.stream.reduce(accumulator);
+  }
+
+  @Override
+  public final <U> U reduce(
+      U identity, BiFunction<U, ? super T, U> accumulator, 
+      BinaryOperator<U> combiner
+  ) {
+    return this.stream.reduce(identity, accumulator, combiner);
+  }
+
+  @Override
+  public final <R> R collect(
+      Supplier<R> supplier, 
+      BiConsumer<R, ? super T> accumulator, 
+      BiConsumer<R, R> combiner
+  ) {
+    return this.stream.collect(supplier, accumulator, combiner);
+  }
+
+  @Override
+  public final <R, A> R collect(Collector<? super T, A, R> collector) {
+    return this.stream.collect(collector);
+  }
+
+  @Override
+  public final Optional<T> min(Comparator<? super T> comparator) {
+    return this.stream.min(comparator);
+  }
+
+  @Override
+  public final Optional<T> max(Comparator<? super T> comparator) {
+    return this.stream.max(comparator);
+  }
+
+  @Override
+  public final long count() {
+    return this.stream.count();
+  }
+
+  @Override
+  public final boolean anyMatch(Predicate<? super T> predicate) {
+    return this.stream.anyMatch(predicate);
+  }
+
+  @Override
+  public final boolean allMatch(Predicate<? super T> predicate) {
+    return this.stream.allMatch(predicate);
+  }
+
+  @Override
+  public final boolean noneMatch(Predicate<? super T> predicate) {
+    return this.stream.noneMatch(predicate);
+  }
+
+  @Override
+  public final Optional<T> findFirst() {
+    return this.stream.findFirst();
+  }
+
+  @Override
+  public final Optional<T> findAny() {
+    return this.stream.findAny();
+  }
+
+  @Override
+  public final Iterator<T> iterator() {
+    return this.stream.iterator();
+  }
+
+  @Override
+  public final Spliterator<T> spliterator() {
+    return this.stream.spliterator();
+  }
+
+  @Override
+  public final boolean isParallel() {
+    return this.stream.isParallel();
+  }
+
+  @Override
+  public final Stream<T> sequential() {
+    return this.stream.sequential();
+  }
+
+  @Override
+  public final Stream<T> parallel() {
+    return this.stream.parallel();
+  }
+
+  @Override
+  public final Stream<T> unordered() {
+    return this.stream.unordered();
+  }
+
+  @Override
+  public final Stream<T> onClose(Runnable closeHandler) {
+    return this.stream.onClose(closeHandler);
+  }
+
+  @Override
+  public final void close() {
+    this.stream.close();
+  }
+}

--- a/src/main/java/org/llorllale/youtrack/api/StreamOf.java
+++ b/src/main/java/org/llorllale/youtrack/api/StreamOf.java
@@ -17,26 +17,9 @@
 package org.llorllale.youtrack.api;
 
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Iterator;
-import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.BinaryOperator;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.IntFunction;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.function.ToDoubleFunction;
-import java.util.function.ToIntFunction;
-import java.util.function.ToLongFunction;
-import java.util.stream.Collector;
-import java.util.stream.DoubleStream;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -47,19 +30,7 @@ import java.util.stream.StreamSupport;
  * @param <T> the stream's type
  * @since 1.0.0
  */
-@SuppressWarnings({"checkstyle:MethodCount", "checkstyle:ClassFanOutComplexity"})
-final class StreamOf<T> implements Stream<T> {
-  private final Stream<T> stream;
-
-  /**
-   * Primary ctor.
-   * 
-   * @param stream the actual stream implementation 
-   * @since 1.0.0
-   */
-  private StreamOf(Stream<T> stream) {
-    this.stream = stream;
-  }
+final class StreamOf<T> extends StreamEnvelope<T> {
 
   /**
    * Encapsulates the collection as a stream.
@@ -68,7 +39,7 @@ final class StreamOf<T> implements Stream<T> {
    * @since 1.0.0
    */
   StreamOf(Collection<T> coll) {
-    this(coll.stream());
+    super(coll.stream());
   }
 
   /**
@@ -78,218 +49,11 @@ final class StreamOf<T> implements Stream<T> {
    * @since 1.0.0
    */
   StreamOf(Iterator<T> iter) {
-    this(
+    super(
         StreamSupport.stream(
             Spliterators.spliteratorUnknownSize(iter, Spliterator.DISTINCT), 
             false
         )
     );
-  }
-
-  @Override
-  public Stream<T> filter(Predicate<? super T> predicate) {
-    return this.stream.filter(predicate);
-  }
-
-  @Override
-  public <R> Stream<R> map(Function<? super T, ? extends R> mapper) {
-    return this.stream.map(mapper);
-  }
-
-  @Override
-  public IntStream mapToInt(ToIntFunction<? super T> mapper) {
-    return this.stream.mapToInt(mapper);
-  }
-
-  @Override
-  public LongStream mapToLong(ToLongFunction<? super T> mapper) {
-    return this.stream.mapToLong(mapper);
-  }
-
-  @Override
-  public DoubleStream mapToDouble(ToDoubleFunction<? super T> mapper) {
-    return this.stream.mapToDouble(mapper);
-  }
-
-  @Override
-  public <R> Stream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
-    return this.stream.flatMap(mapper);
-  }
-
-  @Override
-  public IntStream flatMapToInt(Function<? super T, ? extends IntStream> mapper) {
-    return this.stream.flatMapToInt(mapper);
-  }
-
-  @Override
-  public LongStream flatMapToLong(Function<? super T, ? extends LongStream> mapper) {
-    return this.stream.flatMapToLong(mapper);
-  }
-
-  @Override
-  public DoubleStream flatMapToDouble(Function<? super T, ? extends DoubleStream> mapper) {
-    return this.stream.flatMapToDouble(mapper);
-  }
-
-  @Override
-  public Stream<T> distinct() {
-    return this.stream.distinct();
-  }
-
-  @Override
-  public Stream<T> sorted() {
-    return this.stream.sorted();
-  }
-
-  @Override
-  public Stream<T> sorted(Comparator<? super T> comparator) {
-    return this.stream.sorted(comparator);
-  }
-
-  @Override
-  public Stream<T> peek(Consumer<? super T> action) {
-    return this.stream.peek(action);
-  }
-
-  @Override
-  public Stream<T> limit(long maxSize) {
-    return this.stream.limit(maxSize);
-  }
-
-  @Override
-  public Stream<T> skip(long n) {
-    return this.stream.skip(n);
-  }
-
-  @Override
-  public void forEach(Consumer<? super T> action) {
-    this.stream.forEach(action);
-  }
-
-  @Override
-  public void forEachOrdered(Consumer<? super T> action) {
-    this.stream.forEachOrdered(action);
-  }
-
-  @Override
-  public Object[] toArray() {
-    return this.stream.toArray();
-  }
-
-  @Override
-  public <A> A[] toArray(IntFunction<A[]> generator) {
-    return this.stream.toArray(generator);
-  }
-
-  @Override
-  public T reduce(T identity, BinaryOperator<T> accumulator) {
-    return this.stream.reduce(identity, accumulator);
-  }
-
-  @Override
-  public Optional<T> reduce(BinaryOperator<T> accumulator) {
-    return this.stream.reduce(accumulator);
-  }
-
-  @Override
-  public <U> U reduce(
-      U identity, BiFunction<U, ? super T, U> accumulator, 
-      BinaryOperator<U> combiner
-  ) {
-    return this.stream.reduce(identity, accumulator, combiner);
-  }
-
-  @Override
-  public <R> R collect(
-      Supplier<R> supplier, 
-      BiConsumer<R, ? super T> accumulator, 
-      BiConsumer<R, R> combiner
-  ) {
-    return this.stream.collect(supplier, accumulator, combiner);
-  }
-
-  @Override
-  public <R, A> R collect(Collector<? super T, A, R> collector) {
-    return this.stream.collect(collector);
-  }
-
-  @Override
-  public Optional<T> min(Comparator<? super T> comparator) {
-    return this.stream.min(comparator);
-  }
-
-  @Override
-  public Optional<T> max(Comparator<? super T> comparator) {
-    return this.stream.max(comparator);
-  }
-
-  @Override
-  public long count() {
-    return this.stream.count();
-  }
-
-  @Override
-  public boolean anyMatch(Predicate<? super T> predicate) {
-    return this.stream.anyMatch(predicate);
-  }
-
-  @Override
-  public boolean allMatch(Predicate<? super T> predicate) {
-    return this.stream.allMatch(predicate);
-  }
-
-  @Override
-  public boolean noneMatch(Predicate<? super T> predicate) {
-    return this.stream.noneMatch(predicate);
-  }
-
-  @Override
-  public Optional<T> findFirst() {
-    return this.stream.findFirst();
-  }
-
-  @Override
-  public Optional<T> findAny() {
-    return this.stream.findAny();
-  }
-
-  @Override
-  public Iterator<T> iterator() {
-    return this.stream.iterator();
-  }
-
-  @Override
-  public Spliterator<T> spliterator() {
-    return this.stream.spliterator();
-  }
-
-  @Override
-  public boolean isParallel() {
-    return this.stream.isParallel();
-  }
-
-  @Override
-  public Stream<T> sequential() {
-    return this.stream.sequential();
-  }
-
-  @Override
-  public Stream<T> parallel() {
-    return this.stream.parallel();
-  }
-
-  @Override
-  public Stream<T> unordered() {
-    return this.stream.unordered();
-  }
-
-  @Override
-  public Stream<T> onClose(Runnable closeHandler) {
-    return this.stream.onClose(closeHandler);
-  }
-
-  @Override
-  public void close() {
-    this.stream.close();
   }
 }

--- a/src/main/java/org/llorllale/youtrack/api/XmlAttachment.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlAttachment.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import java.io.IOException;
+import org.llorllale.youtrack.api.session.UnauthorizedException;
+
+/**
+ * An attachment based on XMLs.
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.1.0
+ */
+final class XmlAttachment implements Attachment {
+  private final Xml fileUrl;
+  private final Issue issue;
+
+  /**
+   * Ctor.
+   * @param fileUrl the 'fileUrl' XML element
+   * @param issue the issue of this attachment
+   */
+  XmlAttachment(Xml fileUrl, Issue issue) {
+    this.fileUrl = fileUrl;
+    this.issue = issue;
+  }
+
+  @Override
+  public String name() {
+    return this.fileUrl.textOf("@name").get();
+  }
+
+  @Override
+  public User creator() throws IOException, UnauthorizedException {
+    return this.issue.project().users().user(
+      this.fileUrl.textOf("@authorLogin").get()
+    );
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/XmlAttachmentTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlAttachmentTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+// @checkstyle AvoidStaticImport (1 line)
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+import org.llorllale.youtrack.api.mock.MockIssue;
+import org.llorllale.youtrack.api.mock.MockProject;
+import org.llorllale.youtrack.api.mock.MockUser;
+
+/**
+ * Unit tests for {@link XmlAttachment}.
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.1.0
+ */
+public final class XmlAttachmentTest {
+  /**
+   * XmlAttachment returns the value of the @name attribute.
+   * @since 1.1.0
+   */
+  @Test
+  public void returnsName() {
+    assertThat(
+      new XmlAttachment(
+        // @checkstyle LineLength (1 line)
+        new XmlOf("<fileUrl url=\"/_persistent/uploadFile.html?file=45-46&amp;v=0&amp;c=false\" name=\"uploadFile.html\"/>"),
+        new MockIssue(new MockProject())
+      ).name(),
+      new IsEqual<>("uploadFile.html")
+    );
+  }
+
+  /**
+   * XmlAttachment returns the creator.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @Test
+  public void returnsCreator() throws Exception {
+    final User creator = new MockUser("Joe Rogan", "joe@test.com", "jrogan");
+    assertThat(
+      new XmlAttachment(
+        // @checkstyle LineLength (1 line)
+        new XmlOf("<fileUrl authorLogin=\"jrogan\" url=\"/_persistent/uploadFile.html?file=45-46&amp;v=0&amp;c=false\" name=\"uploadFile.html\"/>"),
+        new MockIssue(new MockProject().withUser(creator))
+      ).creator(),
+      new IsEqual<>(creator)
+    );
+  }
+}


### PR DESCRIPTION
This PR:
* fixes #71
* Adds new `Attachment` interface
* Adds new `Attachments` interface (extends `Stream<Attachment>`)
* Adds new `StreamEnvelope`
*`StreamOf` now extends `StreamEnvelope`
* Leaves puzzle for adding some more attributes to `Attachment`
* Leaves puzzle for implementing `Attachments`