### PR TITLE
(#209) Implemented Attachments interface

### DIFF
--- a/src/main/java/org/llorllale/youtrack/api/Attachments.java
+++ b/src/main/java/org/llorllale/youtrack/api/Attachments.java
@@ -22,8 +22,6 @@ import java.util.stream.Stream;
  * Attachments of an {@link Issue}.
  * @author George Aristy (george.aristy@gmail.com)
  * @since 1.1.0
- * @todo #71 Implement Attachments interface. It is a stream (as anticipated in
- *  #200), and will in the future support creation of attachments.
  */
 public interface Attachments extends Stream<Attachment> {
   

--- a/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+import java.io.IOException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.llorllale.youtrack.api.session.Login;
+
+/**
+ * Default {@link Attachments}.
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.1.0
+ */
+final class DefaultAttachments extends StreamEnvelope<Attachment> implements Attachments {
+  private final Issue issue;
+  private final HttpClient client;
+
+  /**
+   * Ctor.
+   * @param issue owning issue
+   * @param login the user's login
+   * @param client the Http client to use
+   * @throws IOException If an I/O error occurs
+   * @since 1.1.0
+   */
+  DefaultAttachments(Issue issue, Login login, HttpClient client) throws IOException {
+    super(
+      new StreamOf<>(
+        new MappedCollection<>(
+          xml -> new XmlAttachment(xml, issue),
+          new XmlsOf(
+            "/fileUrls/fileUrl",
+            new HttpResponseAsResponse(
+              client.execute(
+                new HttpGet(
+                  login.session().baseUrl().toString().concat(
+                    String.format("/issue/%s/attachment", issue.id())
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    );
+    this.issue = issue;
+    this.client = client;
+  }
+}

--- a/src/main/java/org/llorllale/youtrack/api/Issue.java
+++ b/src/main/java/org/llorllale/youtrack/api/Issue.java
@@ -132,4 +132,12 @@ public interface Issue {
    * @since 0.8.0
    */
   Collection<AssignedField> fields();
+
+  /**
+   * Attachments for this issue.
+   * @return attachments API
+   * @throws IOException if the server is unavailable
+   * @since 1.1.0
+   */
+  Attachments attachments() throws IOException;
 }

--- a/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.llorllale.youtrack.api.session.Login;
 
 import org.llorllale.youtrack.api.session.UnauthorizedException;
@@ -36,6 +38,28 @@ final class XmlIssue implements Issue {
   private final Project project;
   private final Login login;
   private final Xml xml;
+  private final HttpClient client;
+
+  /**
+   * Primary ctor.
+   * 
+   * @param project this {@link Issue issue's} {@link Project}
+   * @param login the user's {@link Login}
+   * @param xml the xml object received from YouTrack
+   * @param client the Http client to use
+   * @since 0.1.0
+   */
+  XmlIssue(
+      Project project, 
+      Login login, 
+      Xml xml,
+      HttpClient client
+  ) {
+    this.project = project;
+    this.login = login;
+    this.xml = xml;
+    this.client = client;
+  }
 
   /**
    * Primary ctor.
@@ -50,9 +74,7 @@ final class XmlIssue implements Issue {
       Login login, 
       Xml xml
   ) {
-    this.project = project;
-    this.login = login;
-    this.xml = xml;
+    this(project, login, xml, HttpClients.createDefault());
   }
 
   @Override
@@ -136,5 +158,10 @@ final class XmlIssue implements Issue {
 
     final Issue other = (Issue) object;
     return this.id().equals(other.id()) && this.project().equals(other.project());
+  }
+
+  @Override
+  public Attachments attachments() throws IOException {
+    return new DefaultAttachments(this, this.login, this.client);
   }
 }

--- a/src/test/java/org/llorllale/youtrack/api/DefaultAttachmentsTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultAttachmentsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+// @checkstyle AvoidStaticImport (1 line)
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+import org.llorllale.youtrack.api.mock.MockIssue;
+import org.llorllale.youtrack.api.mock.MockLogin;
+import org.llorllale.youtrack.api.mock.MockProject;
+import org.llorllale.youtrack.api.mock.http.MockHttpClient;
+import org.llorllale.youtrack.api.mock.http.response.MockOkResponse;
+
+/**
+ * Unit tests for {@link DefaultAttachments}.
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.1.0
+ * @checkstyle MethodName (500 lines)
+ * @checkstyle MagicNumber (500 lines)
+ */
+public final class DefaultAttachmentsTest {
+  /**
+   * DefaultAttachments must stream all attachments for the issue.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @Test
+  public void streamsAttachments() throws Exception {
+    assertThat(
+      new DefaultAttachments(
+        new MockIssue(new MockProject()),
+        new MockLogin(),
+        new MockHttpClient(
+          new MockOkResponse(
+            "<fileUrls>\n"
+            // @checkstyle LineLength (3 lines)
+            + "  <fileUrl url=\"/_persistent/uploadFile.html?file=45-46&amp;v=0&amp;c=false\" name=\"file1.html\"/>\n"
+            + "  <fileUrl url=\"/_persistent/uploadFile.html?file=45-46&amp;v=0&amp;c=false\" name=\"file2.html\"/>\n"
+            + "  <fileUrl url=\"/_persistent/uploadFile.html?file=45-46&amp;v=0&amp;c=false\" name=\"file3.html\"/>\n"
+            + "</fileUrls>"
+          )
+        )
+      ).count(),
+      new IsEqual<>(3L)
+    );
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/XmlIssueTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlIssueTest.java
@@ -24,10 +24,14 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
 import java.time.Instant;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsNull;
 import org.junit.Test;
 import org.llorllale.youtrack.api.mock.MockIssue;
 import org.llorllale.youtrack.api.mock.MockLogin;
 import org.llorllale.youtrack.api.mock.MockProject;
+import org.llorllale.youtrack.api.mock.http.MockHttpClient;
+import org.llorllale.youtrack.api.mock.http.response.MockOkResponse;
 
 /**
  * Unit tests for {@link XmlIssue}.
@@ -255,6 +259,29 @@ public final class XmlIssueTest {
         new MockProject("PR-1", "name", "description"),
         "HBR-64"
       )
+    );
+  }
+
+  /**
+   * XmlIssue returns the attachments API.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @Test
+  public void returnsAttachments() throws Exception {
+    assertThat(
+      new XmlIssue(
+        new MockProject("PR-1", "name", "description"),
+        new MockLogin(),
+        new XmlOf(new StringAsDocument("<issue id=\"HBR-63\"/>")),
+        new MockHttpClient(new MockOkResponse(
+          "<fileUrls>\n"
+          // @checkstyle LineLength (1 line)
+          + "  <fileUrl url=\"/_persistent/uploadFile.html?file=45-46&amp;v=0&amp;c=false\" name=\"uploadFile.html\"/>\n"
+          + "</fileUrls>"
+        ))
+      ).attachments(),
+      new IsNot<>(new IsNull<>())
     );
   }
 }

--- a/src/test/java/org/llorllale/youtrack/api/mock/MockIssue.java
+++ b/src/test/java/org/llorllale/youtrack/api/mock/MockIssue.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.llorllale.youtrack.api.AssignedField;
+import org.llorllale.youtrack.api.Attachments;
 import org.llorllale.youtrack.api.Comments;
 import org.llorllale.youtrack.api.Issue;
 import org.llorllale.youtrack.api.IssueTimeTracking;
@@ -228,5 +229,10 @@ public final class MockIssue implements Issue {
   @Override
   public UpdateIssue update() {
     throw new UnsupportedOperationException("Not supported yet.");
+  }
+
+  @Override
+  public Attachments attachments() throws IOException {
+    throw new UnsupportedOperationException();
   }
 }


### PR DESCRIPTION
This PR:
* solves #209 
* Adds new `DefaultAttachments` implementation
* Adds new `Issue.attachments()` method
* Adds new private attribute `XmlIssue.httpclient` that enables the new `XmlIssueTest.returnsAttachments()` test, and also anticipates work for issue #211 