### PR TITLE
(#72) Attach file to an issue

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -24,6 +24,7 @@ This project includes:
   Apache Commons Codec under The Apache Software License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
+  Apache HttpClient Mime under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
   cactoos-matchers under BSD
   Hamcrest Core under New BSD License

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@
 [![Javadocs](http://javadoc.io/badge/org.llorllale/youtrack-api.svg?color=blue)](http://javadoc.io/doc/org.llorllale/youtrack-api)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://llorllale.github.io/youtrack-api/license.html)
 
-`youtrack-api` is a fluent, object-oriented Java API for [YouTrack](https://www.jetbrains.com/youtrack/). Visit the [project's site](https://llorllale.github.io/youtrack-api) for more info. It has just one dependency: Apache's [HttpClient](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient) version `4.5.x`.
-
-Java 8 or above is required.
+`youtrack-api` is a fluent, object-oriented Java API for [YouTrack](https://www.jetbrains.com/youtrack/). Visit the [project's site](https://llorllale.github.io/youtrack-api) for more info. 
 
 Here's a snippet of its usage:
 
@@ -24,6 +22,12 @@ youtrack.projects().get("project_id").get()
     .comments()
     .post("Hello World!");                  //posts comment to the issue
 ```
+
+## Dependencies
+
+* Java 8+.
+* Apache's [HttpClient](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient) version `4.5.x`.
+* Apache's [HttpClient HttpMime](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime) version `4.5.x`.
 
 ## Feedback
 Please direct any questions, feature requests or bugs to the [issue tracker](https://github.com/llorllale/youtrack-api/issues/).

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
       <version>4.5.1</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>4.5.1</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/src/main/java/org/llorllale/youtrack/api/Attachments.java
+++ b/src/main/java/org/llorllale/youtrack/api/Attachments.java
@@ -16,6 +16,8 @@
 
 package org.llorllale.youtrack.api;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.stream.Stream;
 
 /**
@@ -24,5 +26,14 @@ import java.util.stream.Stream;
  * @since 1.1.0
  */
 public interface Attachments extends Stream<Attachment> {
-  
+  /**
+   * Attaches {@code contents} to the issue.
+   * @param name preferred name for the attachment
+   * @param type content-type of the contents
+   * @param contents the contents
+   * @return this {@link Attachments}
+   * @throws IOException if the server is unavailable or if {@code contents} cannot be read
+   * @since 1.1.0
+   */
+  Attachments create(String name, String type, InputStream contents) throws IOException;
 }

--- a/src/main/java/org/llorllale/youtrack/api/Attachments.java
+++ b/src/main/java/org/llorllale/youtrack/api/Attachments.java
@@ -28,12 +28,12 @@ import java.util.stream.Stream;
 public interface Attachments extends Stream<Attachment> {
   /**
    * Attaches {@code contents} to the issue.
-   * @param name preferred name for the attachment
-   * @param type content-type of the contents
+   * @param filename the attachment's filename
+   * @param type content-type
    * @param contents the contents
    * @return this {@link Attachments}
    * @throws IOException if the server is unavailable or if {@code contents} cannot be read
    * @since 1.1.0
    */
-  Attachments create(String name, String type, InputStream contents) throws IOException;
+  Attachments create(String filename, String type, InputStream contents) throws IOException;
 }

--- a/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
@@ -19,6 +19,7 @@ package org.llorllale.youtrack.api;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.UUID;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -85,6 +86,8 @@ final class DefaultAttachments extends StreamEnvelope<Attachment> implements Att
       this.client.execute(
         new HttpRequestWithEntity(
           MultipartEntityBuilder.create()
+            .setContentType(ContentType.MULTIPART_FORM_DATA)
+            .setBoundary(UUID.randomUUID().toString())
             .addPart(
               FormBodyPartBuilder.create()
                 .setName(name)

--- a/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
@@ -17,8 +17,15 @@
 package org.llorllale.youtrack.api;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.FormBodyPartBuilder;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.entity.mime.content.InputStreamBody;
 import org.llorllale.youtrack.api.session.Login;
 
 /**
@@ -27,7 +34,10 @@ import org.llorllale.youtrack.api.session.Login;
  * @since 1.1.0
  */
 final class DefaultAttachments extends StreamEnvelope<Attachment> implements Attachments {
+  private static final String ATTACHMENTS_PATH = "/issue/%s/attachment";
+
   private final Issue issue;
+  private final Login login;
   private final HttpClient client;
 
   /**
@@ -35,30 +45,63 @@ final class DefaultAttachments extends StreamEnvelope<Attachment> implements Att
    * @param issue owning issue
    * @param login the user's login
    * @param client the Http client to use
-   * @throws IOException If an I/O error occurs
    * @since 1.1.0
    */
-  DefaultAttachments(Issue issue, Login login, HttpClient client) throws IOException {
-    super(
-      new StreamOf<>(
-        new MappedCollection<>(
-          xml -> new XmlAttachment(xml, issue),
-          new XmlsOf(
-            "/fileUrls/fileUrl",
-            new HttpResponseAsResponse(
-              client.execute(
-                new HttpGet(
-                  login.session().baseUrl().toString().concat(
-                    String.format("/issue/%s/attachment", issue.id())
+  DefaultAttachments(Issue issue, Login login, HttpClient client) {
+    super(() -> {
+      try {
+        return new StreamOf<>(
+          new MappedCollection<>(
+            xml -> new XmlAttachment(xml, issue),
+            new XmlsOf(
+              "/fileUrls/fileUrl",
+              new HttpResponseAsResponse(
+                client.execute(
+                  new HttpRequestWithSession(
+                    login.session(),
+                    new HttpGet(
+                      login.session().baseUrl().toString().concat(
+                        String.format(ATTACHMENTS_PATH, issue.id())
+                      )
+                    )
                   )
                 )
               )
             )
           )
+        );
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
+    this.issue = issue;
+    this.login = login;
+    this.client = client;
+  }
+
+  @Override
+  public Attachments create(String name, String type, InputStream contents) throws IOException {
+    new HttpResponseAsResponse(
+      this.client.execute(
+        new HttpRequestWithEntity(
+          MultipartEntityBuilder.create()
+            .addPart(
+              FormBodyPartBuilder.create()
+                .setName(name)
+                .setBody(new InputStreamBody(contents, ContentType.create(type)))
+                .build()
+            ).build(),
+          new HttpRequestWithSession(
+            this.login.session(),
+            new HttpPost(
+              this.login.session().baseUrl().toString().concat(
+                String.format(ATTACHMENTS_PATH, this.issue.id())
+              )
+            )
+          )
         )
       )
-    );
-    this.issue = issue;
-    this.client = client;
+    ).httpResponse();
+    return new DefaultAttachments(this.issue, this.login, this.client);
   }
 }

--- a/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
@@ -24,9 +24,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
-import org.apache.http.entity.mime.FormBodyPartBuilder;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.entity.mime.content.InputStreamBody;
 import org.llorllale.youtrack.api.session.Login;
 
 /**
@@ -81,19 +79,14 @@ final class DefaultAttachments extends StreamEnvelope<Attachment> implements Att
   }
 
   @Override
-  public Attachments create(String name, String type, InputStream contents) throws IOException {
+  public Attachments create(String filename, String type, InputStream contents) throws IOException {
     new HttpResponseAsResponse(
       this.client.execute(
         new HttpRequestWithEntity(
           MultipartEntityBuilder.create()
-            .setContentType(ContentType.MULTIPART_FORM_DATA)
             .setBoundary(UUID.randomUUID().toString())
-            .addPart(
-              FormBodyPartBuilder.create()
-                .setName(name)
-                .setBody(new InputStreamBody(contents, ContentType.create(type)))
-                .build()
-            ).build(),
+            .addBinaryBody(filename, contents, ContentType.create(type), filename)
+            .build(),
           new HttpRequestWithSession(
             this.login.session(),
             new HttpPost(

--- a/src/main/java/org/llorllale/youtrack/api/Issue.java
+++ b/src/main/java/org/llorllale/youtrack/api/Issue.java
@@ -136,8 +136,7 @@ public interface Issue {
   /**
    * Attachments for this issue.
    * @return attachments API
-   * @throws IOException if the server is unavailable
    * @since 1.1.0
    */
-  Attachments attachments() throws IOException;
+  Attachments attachments();
 }

--- a/src/main/java/org/llorllale/youtrack/api/StreamEnvelope.java
+++ b/src/main/java/org/llorllale/youtrack/api/StreamEnvelope.java
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
  */
 @SuppressWarnings("checkstyle:MethodCount")
 abstract class StreamEnvelope<T> implements Stream<T> {
-  private final Stream<T> stream;
+  private final Supplier<Stream<T>> stream;
 
   /**
    * Primary ctor.
@@ -54,112 +54,121 @@ abstract class StreamEnvelope<T> implements Stream<T> {
    * @since 1.0.0
    */
   protected StreamEnvelope(Stream<T> stream) {
+    this.stream = () -> stream;
+  }
+
+  /**
+   * Ctor.
+   * @param stream the actual stream implementation
+   * @since 1.1.0
+   */
+  protected StreamEnvelope(Supplier<Stream<T>> stream) {
     this.stream = stream;
   }
 
   @Override
   public final Stream<T> filter(Predicate<? super T> predicate) {
-    return this.stream.filter(predicate);
+    return this.stream.get().filter(predicate);
   }
 
   @Override
   public final <R> Stream<R> map(Function<? super T, ? extends R> mapper) {
-    return this.stream.map(mapper);
+    return this.stream.get().map(mapper);
   }
 
   @Override
   public final IntStream mapToInt(ToIntFunction<? super T> mapper) {
-    return this.stream.mapToInt(mapper);
+    return this.stream.get().mapToInt(mapper);
   }
 
   @Override
   public final LongStream mapToLong(ToLongFunction<? super T> mapper) {
-    return this.stream.mapToLong(mapper);
+    return this.stream.get().mapToLong(mapper);
   }
 
   @Override
   public final DoubleStream mapToDouble(ToDoubleFunction<? super T> mapper) {
-    return this.stream.mapToDouble(mapper);
+    return this.stream.get().mapToDouble(mapper);
   }
 
   @Override
   public final <R> Stream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
-    return this.stream.flatMap(mapper);
+    return this.stream.get().flatMap(mapper);
   }
 
   @Override
   public final IntStream flatMapToInt(Function<? super T, ? extends IntStream> mapper) {
-    return this.stream.flatMapToInt(mapper);
+    return this.stream.get().flatMapToInt(mapper);
   }
 
   @Override
   public final LongStream flatMapToLong(Function<? super T, ? extends LongStream> mapper) {
-    return this.stream.flatMapToLong(mapper);
+    return this.stream.get().flatMapToLong(mapper);
   }
 
   @Override
   public final DoubleStream flatMapToDouble(Function<? super T, ? extends DoubleStream> mapper) {
-    return this.stream.flatMapToDouble(mapper);
+    return this.stream.get().flatMapToDouble(mapper);
   }
 
   @Override
   public final Stream<T> distinct() {
-    return this.stream.distinct();
+    return this.stream.get().distinct();
   }
 
   @Override
   public final Stream<T> sorted() {
-    return this.stream.sorted();
+    return this.stream.get().sorted();
   }
 
   @Override
   public final Stream<T> sorted(Comparator<? super T> comparator) {
-    return this.stream.sorted(comparator);
+    return this.stream.get().sorted(comparator);
   }
 
   @Override
   public final Stream<T> peek(Consumer<? super T> action) {
-    return this.stream.peek(action);
+    return this.stream.get().peek(action);
   }
 
   @Override
   public final Stream<T> limit(long maxSize) {
-    return this.stream.limit(maxSize);
+    return this.stream.get().limit(maxSize);
   }
 
   @Override
   public final Stream<T> skip(long n) {
-    return this.stream.skip(n);
+    return this.stream.get().skip(n);
   }
 
   @Override
   public final void forEach(Consumer<? super T> action) {
-    this.stream.forEach(action);
+    this.stream.get().forEach(action);
   }
 
   @Override
   public final void forEachOrdered(Consumer<? super T> action) {
-    this.stream.forEachOrdered(action);
+    this.stream.get().forEachOrdered(action);
   }
 
   @Override
   public final Object[] toArray() {
-    return this.stream.toArray();
+    return this.stream.get().toArray();
   }
 
   @Override
   public final <A> A[] toArray(IntFunction<A[]> generator) {
-    return this.stream.toArray(generator);
+    return this.stream.get().toArray(generator);
   }
 
   @Override
   public final T reduce(T identity, BinaryOperator<T> accumulator) {
-    return this.stream.reduce(identity, accumulator);
+    return this.stream.get().reduce(identity, accumulator);
   }
 
   @Override
   public final Optional<T> reduce(BinaryOperator<T> accumulator) {
-    return this.stream.reduce(accumulator);
+    return this.stream.get().reduce(accumulator);
   }
 
   @Override
@@ -167,7 +176,7 @@ abstract class StreamEnvelope<T> implements Stream<T> {
       U identity, BiFunction<U, ? super T, U> accumulator, 
       BinaryOperator<U> combiner
   ) {
-    return this.stream.reduce(identity, accumulator, combiner);
+    return this.stream.get().reduce(identity, accumulator, combiner);
   }
 
   @Override
@@ -176,91 +185,91 @@ abstract class StreamEnvelope<T> implements Stream<T> {
       BiConsumer<R, ? super T> accumulator, 
       BiConsumer<R, R> combiner
   ) {
-    return this.stream.collect(supplier, accumulator, combiner);
+    return this.stream.get().collect(supplier, accumulator, combiner);
   }
 
   @Override
   public final <R, A> R collect(Collector<? super T, A, R> collector) {
-    return this.stream.collect(collector);
+    return this.stream.get().collect(collector);
   }
 
   @Override
   public final Optional<T> min(Comparator<? super T> comparator) {
-    return this.stream.min(comparator);
+    return this.stream.get().min(comparator);
   }
 
   @Override
   public final Optional<T> max(Comparator<? super T> comparator) {
-    return this.stream.max(comparator);
+    return this.stream.get().max(comparator);
   }
 
   @Override
   public final long count() {
-    return this.stream.count();
+    return this.stream.get().count();
   }
 
   @Override
   public final boolean anyMatch(Predicate<? super T> predicate) {
-    return this.stream.anyMatch(predicate);
+    return this.stream.get().anyMatch(predicate);
   }
 
   @Override
   public final boolean allMatch(Predicate<? super T> predicate) {
-    return this.stream.allMatch(predicate);
+    return this.stream.get().allMatch(predicate);
   }
 
   @Override
   public final boolean noneMatch(Predicate<? super T> predicate) {
-    return this.stream.noneMatch(predicate);
+    return this.stream.get().noneMatch(predicate);
   }
 
   @Override
   public final Optional<T> findFirst() {
-    return this.stream.findFirst();
+    return this.stream.get().findFirst();
   }
 
   @Override
   public final Optional<T> findAny() {
-    return this.stream.findAny();
+    return this.stream.get().findAny();
   }
 
   @Override
   public final Iterator<T> iterator() {
-    return this.stream.iterator();
+    return this.stream.get().iterator();
   }
 
   @Override
   public final Spliterator<T> spliterator() {
-    return this.stream.spliterator();
+    return this.stream.get().spliterator();
   }
 
   @Override
   public final boolean isParallel() {
-    return this.stream.isParallel();
+    return this.stream.get().isParallel();
   }
 
   @Override
   public final Stream<T> sequential() {
-    return this.stream.sequential();
+    return this.stream.get().sequential();
   }
 
   @Override
   public final Stream<T> parallel() {
-    return this.stream.parallel();
+    return this.stream.get().parallel();
   }
 
   @Override
   public final Stream<T> unordered() {
-    return this.stream.unordered();
+    return this.stream.get().unordered();
   }
 
   @Override
   public final Stream<T> onClose(Runnable closeHandler) {
-    return this.stream.onClose(closeHandler);
+    return this.stream.get().onClose(closeHandler);
   }
 
   @Override
   public final void close() {
-    this.stream.close();
+    this.stream.get().close();
   }
 }

--- a/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
@@ -161,7 +161,7 @@ final class XmlIssue implements Issue {
   }
 
   @Override
-  public Attachments attachments() throws IOException {
+  public Attachments attachments() {
     return new DefaultAttachments(this, this.login, this.client);
   }
 }

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -46,6 +46,12 @@ $h4 Snippet
 
 <br/>
 
+$h4 Dependencies
+
+* Java 8+.
+* Apache's [HttpClient](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient) version `4.5.x`.
+* Apache's [HttpClient HttpMime](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime) version `4.5.x`.
+
 $h4 Goals
 The goals of this project include:
 

--- a/src/test/java/org/llorllale/youtrack/api/DefaultAttachmentsIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultAttachmentsIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+// @checkstyle AvoidStaticImport (1 line)
+import static org.junit.Assert.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.UUID;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.HttpClients;
+import org.hamcrest.core.IsEqual;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.llorllale.youtrack.api.session.Login;
+import org.llorllale.youtrack.api.session.PermanentToken;
+
+/**
+ * Integration tests for {@link DefaultAttachments}.
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.1.0
+ * @checkstyle MultipleStringLiterals (500 lines)
+ * @checkstyle MethodName (500 lines)
+ * @checkstyle AbbreviationAsWordInName (3 lines)
+ */
+public final class DefaultAttachmentsIT {
+  private static IntegrationTestsConfig config;
+  private static Login login;
+  private static Issue issue;
+
+  /**
+   * Setup.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @BeforeClass
+  public static void setup() throws Exception {
+    config = new IntegrationTestsConfig();
+    login = new PermanentToken(
+      config.youtrackUrl(), 
+      config.youtrackUserToken()
+    );
+    issue = new DefaultYouTrack(login)
+      .projects()
+      .stream()
+      .findFirst()
+      .get()
+      .issues()
+      .create(DefaultAttachmentsIT.class.getSimpleName(), "Description");
+  }
+
+  /**
+   * Creates the attachment.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @Test
+  public void createsAttachment() throws Exception {
+    assertThat(
+      new DefaultAttachments(issue, login, HttpClients.createDefault())
+        .create(
+          "test", ContentType.TEXT_PLAIN.getMimeType(),
+          new ByteArrayInputStream("This is a test attachment".getBytes())
+        ).count(),
+      new IsEqual<>(1L)
+    );
+  }
+
+  /**
+   * Creates the attachment with the given name.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @Test
+  public void createsAttachmentWithName() throws Exception {
+    final String name = UUID.randomUUID().toString();
+    assertThat(
+      new DefaultAttachments(issue, login, HttpClients.createDefault())
+        .create(
+          name, ContentType.TEXT_PLAIN.getMimeType(),
+          new ByteArrayInputStream("This is a test attachment".getBytes())
+        ).anyMatch(a -> name.equals(a.name())),
+      new IsEqual<>(true)
+    );   
+  }
+
+  /**
+   * Creates the attachment with the same user login used in this test.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @Test
+  public void createsTheAttachmentWithTheUser() throws Exception {
+    final String name = UUID.randomUUID().toString();
+    assertThat(
+      new DefaultAttachments(issue, login, HttpClients.createDefault())
+        .create(
+          name, ContentType.TEXT_PLAIN.getMimeType(),
+          new ByteArrayInputStream("This is a test attachment".getBytes())
+        ).anyMatch(a -> {
+          try {
+            return name.equals(a.name()) && config.youtrackUser().equals(a.creator().name());
+          } catch (IOException e) {
+            throw new IllegalStateException(e);
+          }
+        }),
+      new IsEqual<>(true)
+    );   
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/DefaultAttachmentsIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultAttachmentsIT.java
@@ -74,7 +74,7 @@ public final class DefaultAttachmentsIT {
     assertThat(
       new DefaultAttachments(issue, login, HttpClients.createDefault())
         .create(
-          "test", ContentType.TEXT_PLAIN.getMimeType(),
+          "test.txt", ContentType.TEXT_PLAIN.getMimeType(),
           new ByteArrayInputStream("This is a test attachment".getBytes())
         ).count(),
       new IsEqual<>(1L)

--- a/src/test/java/org/llorllale/youtrack/api/mock/MockIssue.java
+++ b/src/test/java/org/llorllale/youtrack/api/mock/MockIssue.java
@@ -232,7 +232,7 @@ public final class MockIssue implements Issue {
   }
 
   @Override
-  public Attachments attachments() throws IOException {
+  public Attachments attachments() {
     throw new UnsupportedOperationException();
   }
 }


### PR DESCRIPTION
This PR:
* fixes #72 
* Adds Apache's `httpmime` as dependency
* Implemented `Attachments.create()`
* Added `StreamEnvelope(Supplier<Stream<T>>)` in order to enable deferred executions and, hence, "auto-update" of `DefaultAttachments`. Without this change, an instance of `DefaultAttachments` would always stay preloaded with a fixed set of attachments
* Refactors `Issue.attachments()` to not throw `IOException`
