### PR TITLE
(#73) Delete attachments with Attachment.delete()

### DIFF
--- a/src/main/java/org/llorllale/youtrack/api/Attachment.java
+++ b/src/main/java/org/llorllale/youtrack/api/Attachment.java
@@ -32,15 +32,27 @@ public interface Attachment {
   /**
    * This attachment's name.
    * @return name of attachment
+   * @since 1.1.0
    */
   String name();
 
   /**
-   * This attahment's creator.
+   * This attachment's creator.
    * @return the creator
    * @throws IOException if the server is unavailable
    * @throws UnauthorizedException if the user's {@link Login} is not authorized to perform this
    *     operation
+   * @since 1.1.0
    */
   User creator() throws IOException, UnauthorizedException;
+
+  /**
+   * Delete this attachment.
+   * @return the {@link Attachments} API
+   * @throws IOException if the server is unavailable
+   * @throws UnauthorizedException if the user's {@link Login} is not authorized to perform this
+   *     operation
+   * @since 1.1.0
+   */
+  Attachments delete() throws IOException, UnauthorizedException;
 }

--- a/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultAttachments.java
@@ -51,7 +51,7 @@ final class DefaultAttachments extends StreamEnvelope<Attachment> implements Att
       try {
         return new StreamOf<>(
           new MappedCollection<>(
-            xml -> new XmlAttachment(xml, issue),
+            xml -> new XmlAttachment(xml, issue, login, client),
             new XmlsOf(
               "/fileUrls/fileUrl",
               new HttpResponseAsResponse(

--- a/src/test/java/org/llorllale/youtrack/api/XmlAttachmentIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlAttachmentIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.youtrack.api;
+
+// @checkstyle AvoidStaticImport (1 line)
+import static org.junit.Assert.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.util.UUID;
+import org.hamcrest.core.IsEqual;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.llorllale.youtrack.api.session.Login;
+import org.llorllale.youtrack.api.session.PermanentToken;
+
+/**
+ * Integration tests for {@link XmlAttachment}.
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 1.1.0
+ * @checkstyle AbbreviationAsWordInName (3 lines)
+ */
+public final class XmlAttachmentIT {
+  private static IntegrationTestsConfig config;
+  private static Login login;
+  private static Issue issue;
+
+  /**
+   * Setup.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @BeforeClass
+  public static void setup() throws Exception {
+    config = new IntegrationTestsConfig();
+    login = new PermanentToken(
+      config.youtrackUrl(), 
+      config.youtrackUserToken()
+    );
+    issue = new DefaultYouTrack(login)
+      .projects()
+      .stream()
+      .findFirst()
+      .get()
+      .issues()
+      .create(DefaultAttachmentsIT.class.getSimpleName(), "Description");
+  }
+
+  /**
+   * XmlAttachment can effectively delete itself.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @Test
+  public void deletesAttachment() throws Exception {
+    final String name = UUID.randomUUID().toString();
+    assertThat(
+      issue.attachments().create(
+        name, "text/plain", new ByteArrayInputStream("test".getBytes())
+      ).filter(att -> name.equals(att.name()))
+        .findAny().get()
+        .delete()
+        .anyMatch(att -> name.equals(att.name())),
+      new IsEqual<>(false)
+    );
+  }
+}

--- a/src/test/java/org/llorllale/youtrack/api/XmlAttachmentTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlAttachmentTest.java
@@ -22,8 +22,10 @@ import static org.junit.Assert.assertThat;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.youtrack.api.mock.MockIssue;
+import org.llorllale.youtrack.api.mock.MockLogin;
 import org.llorllale.youtrack.api.mock.MockProject;
 import org.llorllale.youtrack.api.mock.MockUser;
+import org.llorllale.youtrack.api.mock.http.MockHttpClient;
 
 /**
  * Unit tests for {@link XmlAttachment}.
@@ -41,7 +43,9 @@ public final class XmlAttachmentTest {
       new XmlAttachment(
         // @checkstyle LineLength (1 line)
         new XmlOf("<fileUrl url=\"/_persistent/uploadFile.html?file=45-46&amp;v=0&amp;c=false\" name=\"uploadFile.html\"/>"),
-        new MockIssue(new MockProject())
+        new MockIssue(new MockProject()),
+        new MockLogin(),
+        new MockHttpClient()
       ).name(),
       new IsEqual<>("uploadFile.html")
     );
@@ -59,7 +63,9 @@ public final class XmlAttachmentTest {
       new XmlAttachment(
         // @checkstyle LineLength (1 line)
         new XmlOf("<fileUrl authorLogin=\"jrogan\" url=\"/_persistent/uploadFile.html?file=45-46&amp;v=0&amp;c=false\" name=\"uploadFile.html\"/>"),
-        new MockIssue(new MockProject().withUser(creator))
+        new MockIssue(new MockProject().withUser(creator)),
+        new MockLogin(),
+        new MockHttpClient()
       ).creator(),
       new IsEqual<>(creator)
     );

--- a/src/test/java/org/llorllale/youtrack/api/mock/http/MockHttpClient.java
+++ b/src/test/java/org/llorllale/youtrack/api/mock/http/MockHttpClient.java
@@ -60,6 +60,16 @@ public final class MockHttpClient implements HttpClient {
     this.intermediateResponses = new ArrayDeque<>(Arrays.asList(intermediateResponses));
   }
 
+  /**
+   * Ctor.
+   * 
+   * <p>A null response will be returned.
+   * @since 1.1.0
+   */
+  public MockHttpClient() {
+    this(null);
+  }
+
   @Override
   public HttpParams getParams() {
     throw new UnsupportedOperationException("Not supported yet.");


### PR DESCRIPTION
This PR:
* fixed #73 
* Implements `Attachment.delete()`