### PR TITLE
(#208) Read attachment contents with `Attachment.contents()`

### DIFF
--- a/src/main/java/org/llorllale/youtrack/api/Attachment.java
+++ b/src/main/java/org/llorllale/youtrack/api/Attachment.java
@@ -17,6 +17,7 @@
 package org.llorllale.youtrack.api;
 
 import java.io.IOException;
+import java.io.InputStream;
 import org.llorllale.youtrack.api.session.Login;
 import org.llorllale.youtrack.api.session.UnauthorizedException;
 
@@ -24,9 +25,6 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * An attachment.
  * @author George Aristy (george.aristy@gmail.com)
  * @since 1.1.0
- * @todo #71 Add an attribute to Attachment for its contents. This would return an
- *  InputStream with the attachment's contents. Add another attribute for the
- *  attachment's content-type.
  */
 public interface Attachment {
   /**
@@ -45,6 +43,14 @@ public interface Attachment {
    * @since 1.1.0
    */
   User creator() throws IOException, UnauthorizedException;
+
+  /**
+   * The contents of this attachment.
+   * @return the contents
+   * @throws IOException if the server is unavailable
+   * @since 1.1.0
+   */
+  InputStream contents() throws IOException;
 
   /**
    * Delete this attachment.

--- a/src/main/java/org/llorllale/youtrack/api/XmlAttachment.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlAttachment.java
@@ -17,8 +17,10 @@
 package org.llorllale.youtrack.api;
 
 import java.io.IOException;
+import java.io.InputStream;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
 import org.llorllale.youtrack.api.session.Login;
 import org.llorllale.youtrack.api.session.UnauthorizedException;
 
@@ -58,6 +60,20 @@ final class XmlAttachment implements Attachment {
     return this.issue.project().users().user(
       this.fileUrl.textOf("@authorLogin").get()
     );
+  }
+
+  @Override
+  public InputStream contents() throws IOException {
+    return new HttpResponseAsResponse(
+      this.client.execute(
+        new HttpRequestWithSession(
+          this.login.session(),
+          new HttpGet(
+            this.fileUrl.textOf("@url").get()
+          )
+        )
+      )
+    ).httpResponse().getEntity().getContent();
   }
 
   @Override

--- a/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
@@ -31,8 +31,11 @@ import org.llorllale.youtrack.api.session.UnauthorizedException;
  * 
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.1.0
+ * @todo #208 The HTTP client configured for XmlIssue is the default one that only pools
+ *  2 connection that are not being released for reuse. Therefore the code hangs after
+ *  a few calls to issue.attachments() and everything else accessible from there. This
+ *  problem is probably present in the rest of the implementations.
  */
-//equals and hashCode tip the method count to just over the max allowed (12) to the actual 14
 @SuppressWarnings("checkstyle:MethodCount")
 final class XmlIssue implements Issue {
   private final Project project;

--- a/src/test/java/org/llorllale/youtrack/api/XmlAttachmentIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlAttachmentIT.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.util.UUID;
 import org.hamcrest.core.IsEqual;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.llorllale.youtrack.api.session.Login;
 import org.llorllale.youtrack.api.session.PermanentToken;
@@ -33,6 +34,7 @@ import org.llorllale.youtrack.api.session.PermanentToken;
  * @since 1.1.0
  * @checkstyle AbbreviationAsWordInName (3 lines)
  */
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
 public final class XmlAttachmentIT {
   private static IntegrationTestsConfig config;
   private static Login login;
@@ -75,6 +77,33 @@ public final class XmlAttachmentIT {
         .delete()
         .anyMatch(att -> name.equals(att.name())),
       new IsEqual<>(false)
+    );
+  }
+
+  /**
+   * XmlAttachment can read the contents.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   * @todo #208 The YouTrack API inside the test docker container is returning 'fileUrl/@url'
+   *  without the mapped port number for the docker container. This is probably because the
+   *  service inside uses port 80. Figure out a way to make it so that the returned
+   *  '@url' is a URL that can be readily accessed from outside the container, and then
+   *  un-ignore this test.
+   */
+  @Ignore
+  @Test
+  public void downloadsAttachment() throws Exception {
+    final String name = UUID.randomUUID().toString();
+    final String contents = UUID.randomUUID().toString();
+    assertThat(
+      new InputStreamAsString().apply(
+        issue.attachments().create(
+          name, "text/plain", new ByteArrayInputStream(contents.getBytes())
+        ).filter(att -> name.equals(att.name()))
+          .findAny().get()
+          .contents()
+        ),
+      new IsEqual<>(contents)
     );
   }
 }

--- a/src/test/java/org/llorllale/youtrack/api/XmlAttachmentTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlAttachmentTest.java
@@ -26,12 +26,14 @@ import org.llorllale.youtrack.api.mock.MockLogin;
 import org.llorllale.youtrack.api.mock.MockProject;
 import org.llorllale.youtrack.api.mock.MockUser;
 import org.llorllale.youtrack.api.mock.http.MockHttpClient;
+import org.llorllale.youtrack.api.mock.http.response.MockOkResponse;
 
 /**
  * Unit tests for {@link XmlAttachment}.
  * @author George Aristy (george.aristy@gmail.com)
  * @since 1.1.0
  */
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
 public final class XmlAttachmentTest {
   /**
    * XmlAttachment returns the value of the @name attribute.
@@ -68,6 +70,30 @@ public final class XmlAttachmentTest {
         new MockHttpClient()
       ).creator(),
       new IsEqual<>(creator)
+    );
+  }
+
+  /**
+   * XmlAttachment returns the contents.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @Test
+  public void returnsContents() throws Exception {
+    final String contents = "test content";
+    assertThat(
+      new InputStreamAsString().apply(
+        new XmlAttachment(
+          new XmlOf(
+            // @checkstyle LineLength (1 line)
+            "<fileUrl authorLogin=\"jrogan\" url=\"/_persistent/uploadFile.html?file=45-46&amp;v=0&amp;c=false\" name=\"uploadFile.html\"/>"
+          ),
+          new MockIssue(new MockProject()),
+          new MockLogin(),
+          new MockHttpClient(new MockOkResponse(contents))
+        ).contents()
+      ),
+      new IsEqual<>(contents)
     );
   }
 }


### PR DESCRIPTION
This PR:
* solves #208 
* Implements `Attachment.contents()`
* Leaves puzzle for configuring the test youtrack to return reachable urls for the contents of attachments
* Leaves puzzle for fixing the fact that we're using the very limited `HttpClients.createDefault()` clients that only manage connection pools of size 2, and we're not releasing them for reuse