### PR TITLE
(#231) Continued making implementations accept HttpClient

### DIFF
--- a/src/main/java/org/llorllale/youtrack/api/DefaultUpdateIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultUpdateIssue.java
@@ -23,10 +23,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.http.client.HttpClient;
 
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 
 import org.llorllale.youtrack.api.session.Login;
@@ -42,17 +42,20 @@ final class DefaultUpdateIssue implements UpdateIssue {
   private static final String PATH_TEMPLATE = "/issue/%s";
   private final Issue issue;
   private final Login login;
+  private final HttpClient client;
 
   /**
    * Primary ctor.
    * 
    * @param issue the issue to update
    * @param login the user's {@link Login}
-   * @since 0.9.0
+   * @param client the {@link HttpClient} to use
+   * @since 1.1.0
    */
-  DefaultUpdateIssue(Issue issue, Login login) {
+  DefaultUpdateIssue(Issue issue, Login login, HttpClient client) {
     this.issue = issue;
     this.login = login;
+    this.client = client;
   }
 
   @Override
@@ -82,7 +85,7 @@ final class DefaultUpdateIssue implements UpdateIssue {
   public Issue fields(Map<Field, FieldValue> fields) throws IOException, UnauthorizedException {
     final String separator = " ";
     new HttpResponseAsResponse(
-      HttpClients.createDefault().execute(
+      this.client.execute(
         new HttpRequestWithSession(
           this.login.session(),
           new HttpRequestWithEntity(
@@ -125,7 +128,7 @@ final class DefaultUpdateIssue implements UpdateIssue {
   private Issue updateSmmryDesc(String summary, String description) 
       throws IOException, UnauthorizedException {
     new HttpResponseAsResponse(
-      HttpClients.createDefault().execute(
+      this.client.execute(
         new HttpRequestWithSession(
           this.login.session(),
           new HttpPost(

--- a/src/main/java/org/llorllale/youtrack/api/DefaultYouTrack.java
+++ b/src/main/java/org/llorllale/youtrack/api/DefaultYouTrack.java
@@ -43,7 +43,7 @@ public final class DefaultYouTrack implements YouTrack {
    * @param login the user's {@link Login}
    * @param httpClient the {@link HttpClient} to use
    * @since 1.1.0
-   * @todo #228 Continue making all implementations accept an HttpClient in order to enable
+   * @todo #231 Continue making all implementations accept an HttpClient in order to enable
    *  concurrency. Right now major parts of the API are hanging when multiple threads are
    *  accessing them.
    */

--- a/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlIssue.java
@@ -112,7 +112,7 @@ final class XmlIssue implements Issue {
 
   @Override
   public UpdateIssue update() {
-    return new DefaultUpdateIssue(this, this.login);
+    return new DefaultUpdateIssue(this, this.login, this.client);
   }
 
   @Override

--- a/src/main/java/org/llorllale/youtrack/api/XmlProject.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlProject.java
@@ -107,6 +107,6 @@ final class XmlProject implements Project {
 
   @Override
   public UsersOfProject users() {
-    return new XmlUsersOfProject(this, this.login, this.xml);
+    return new XmlUsersOfProject(this, this.login, this.xml, this.client);
   }
 }

--- a/src/main/java/org/llorllale/youtrack/api/XmlUsersOfProject.java
+++ b/src/main/java/org/llorllale/youtrack/api/XmlUsersOfProject.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 import org.apache.http.client.HttpClient;
 
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.HttpClients;
 import org.llorllale.youtrack.api.session.Login;
 
 import org.llorllale.youtrack.api.session.UnauthorizedException;
@@ -52,18 +51,6 @@ final class XmlUsersOfProject implements UsersOfProject {
     this.login = login;
     this.xml = xml;
     this.httpClient = httpClient;
-  }
-
-  /**
-   * Ctor.
-   * 
-   * @param project the {@link Project} in scope
-   * @param login the users's {@link Login}
-   * @param xml the xml object received from YouTrack for this {@link #project() project}
-   * @since 1.0.0
-   */
-  XmlUsersOfProject(Project project, Login login, Xml xml) {
-    this(project, login, xml, HttpClients.createDefault());
   }
 
   @Override

--- a/src/test/java/org/llorllale/youtrack/api/DefaultUpdateIssueIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultUpdateIssueIT.java
@@ -20,6 +20,7 @@ package org.llorllale.youtrack.api;
 import static org.junit.Assert.assertNotEquals;
 
 import java.util.HashMap;
+import org.apache.http.impl.client.HttpClients;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.llorllale.youtrack.api.session.Login;
@@ -67,7 +68,9 @@ public final class DefaultUpdateIssueIT {
     final String newSummary = DefaultUpdateIssueIT.class.getSimpleName()
       .concat(".testSummary");
     assertNotEquals(
-      new DefaultUpdateIssue(issue, login).summary(newSummary).summary(),
+      new DefaultUpdateIssue(
+        issue, login, HttpClients.createDefault()
+      ).summary(newSummary).summary(),
       issue.summary()
     );
   }
@@ -81,7 +84,7 @@ public final class DefaultUpdateIssueIT {
     final String newDesc = DefaultUpdateIssueIT.class.getSimpleName()
       .concat("testDescription");
     assertNotEquals(
-      new DefaultUpdateIssue(issue, login)
+      new DefaultUpdateIssue(issue, login, HttpClients.createDefault())
         .description(newDesc)
         .description(),
       issue.description()
@@ -98,7 +101,7 @@ public final class DefaultUpdateIssueIT {
       .concat("testSummaryAndDesc_summ");
     final String newDesc = DefaultUpdateIssueIT.class.getSimpleName()
       .concat("testSummaryAndDesc_desc");
-    final Issue newIssue = new DefaultUpdateIssue(issue, login)
+    final Issue newIssue = new DefaultUpdateIssue(issue, login, HttpClients.createDefault())
       .summaryAndDesc(newSummary, newDesc);
     assertNotEquals(issue.summary(), newIssue.summary());
     assertNotEquals(issue.description(), newIssue.description());
@@ -120,7 +123,7 @@ public final class DefaultUpdateIssueIT {
       .filter(v -> !v.equals(oldValue))
       .findAny().get();
     assertNotEquals(
-      new DefaultUpdateIssue(issue, login)
+      new DefaultUpdateIssue(issue, login, HttpClients.createDefault())
         .field(field, newValue).fields()
         .stream()
         .filter(f -> f.isSameField(field))
@@ -154,7 +157,7 @@ public final class DefaultUpdateIssueIT {
       .values()
       .filter(v -> !v.equals(secondOldVal))
       .findAny().get();
-    new DefaultUpdateIssue(issue, login).fields(
+    new DefaultUpdateIssue(issue, login, HttpClients.createDefault()).fields(
       new HashMap<Field, FieldValue>() {
         {
           put(firstField, firstNewVal);

--- a/src/test/java/org/llorllale/youtrack/api/XmlUsersOfProjectIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlUsersOfProjectIT.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.http.impl.client.HttpClients;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.llorllale.youtrack.api.session.Login;
@@ -55,8 +56,9 @@ public final class XmlUsersOfProjectIT {
   @Test
   public void testUser() throws Exception {
     assertThat(
-      new XmlUsersOfProject(project, login, this.xmlObject("random"))
-        .user(config.youtrackUser())
+      new XmlUsersOfProject(
+        project, login, this.xmlObject("random"), HttpClients.createDefault()
+      ).user(config.youtrackUser())
         .loginName(),
       is(config.youtrackUser())
     );
@@ -69,8 +71,9 @@ public final class XmlUsersOfProjectIT {
   @Test
   public void testAssignees() throws Exception {
     assertTrue(
-      new XmlUsersOfProject(project, login, this.xmlObject(config.youtrackUser()))
-        .assignees()
+      new XmlUsersOfProject(
+        project, login, this.xmlObject(config.youtrackUser()), HttpClients.createDefault()
+      ).assignees()
         .anyMatch(a -> config.youtrackUser().equals(a.loginName()))
     );
   }

--- a/src/test/java/org/llorllale/youtrack/api/XmlUsersOfProjectTest.java
+++ b/src/test/java/org/llorllale/youtrack/api/XmlUsersOfProjectTest.java
@@ -44,7 +44,7 @@ public final class XmlUsersOfProjectTest {
   public void project() {
     final Project project = new MockProject();
     assertThat(
-      new XmlUsersOfProject(project, null, null).project(),
+      new XmlUsersOfProject(project, null, null, null).project(),
       is(project)
     );
   }


### PR DESCRIPTION
This PR is for #231:
* Continued spreading the instance of `HttpClient` to implementations
* Left puzzle for the rest