### PR TITLE
(#243) Can now create projects with Projects.create()

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Here's a snippet of its usage:
 final YouTrack youtrack = new DefaultYouTrack(
     new PermanentToken(new URL("http://youtrack"), "your_token")
 );
-youtrack.projects().get("project_id").get()
+final User leader = youtrack.users()        //Users API under construction - see #246
+  .filter(u -> u.loginName().equals("mike"))
+  .findFirst().get();
+youtrack.projects()
+    .create("TP", "Test Project", leader)   //creates project
     .issues()
     .create("summary", "description")       //creates issue
     .comments()

--- a/src/main/java/org/llorllale/youtrack/api/Projects.java
+++ b/src/main/java/org/llorllale/youtrack/api/Projects.java
@@ -51,4 +51,18 @@ public interface Projects {
    * @since 0.6.0
    */
   Optional<Project> get(String id) throws IOException, UnauthorizedException;
+
+  /**
+   * Create a new {@link Project}.
+   * @param id unique identifier of the project to be created. This short name will be used as
+   *    prefix in issue IDs for this project.
+   * @param name unique, full name of the new project.
+   * @param leader user to be assigned as the project's leader.
+   * @return the newly-created project
+   * @throws IOException if the server is unavailable
+   * @throws UnauthorizedException if the user's {@link Login} is not authorized to perform this
+   *     operation
+   * @since 1.1.0
+   */
+  Project create(String id, String name, User leader) throws IOException, UnauthorizedException;
 }

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -33,10 +33,14 @@ The `YouTrack` interface is the entry point to the rest of the API:
     final YouTrack youtrack = new DefaultYouTrack(login);
 
 #### Projects
-You can fetch projects with the `Projects` interface. If you have a project's ID
-you can simply:
+You can fetch and create projects with the `Projects` interface.
+##### Fetch:
 
     final Optional<Project> project = youtrack.projects().get("project_id");
+
+##### Create:
+    final User leader = ...
+    final Project project = youtrack.projects().create("project_id", "project_name", leader);
 
 You can also access a regular Java 8 stream of all projects accessible by 
 you using `Projects#stream()`:

--- a/src/test/java/org/llorllale/youtrack/api/DefaultIssueTimeTrackingIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultIssueTimeTrackingIT.java
@@ -213,8 +213,7 @@ public final class DefaultIssueTimeTrackingIT {
   private Issue issue(String description) throws Exception {
     return new DefaultYouTrack(login)
       .projects()
-      .stream()
-      .findFirst()
+      .get(config.youtrackTestProjectId())
       .get()
       .issues()
       .create(DefaultIssueTimeTrackingIT.class.getSimpleName(), description);

--- a/src/test/java/org/llorllale/youtrack/api/DefaultProjectTimeTrackingIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultProjectTimeTrackingIT.java
@@ -44,7 +44,7 @@ public final class DefaultProjectTimeTrackingIT {
   public static void setup() throws Exception {
     final IntegrationTestsConfig config = new IntegrationTestsConfig();
     login = new PermanentToken(config.youtrackUrl(), config.youtrackUserToken());
-    project = new DefaultYouTrack(login).projects().stream().findAny().get();
+    project = new DefaultYouTrack(login).projects().get(config.youtrackTestProjectId()).get();
   }
 
   /**

--- a/src/test/java/org/llorllale/youtrack/api/DefaultProjectsIT.java
+++ b/src/test/java/org/llorllale/youtrack/api/DefaultProjectsIT.java
@@ -16,12 +16,16 @@
 
 package org.llorllale.youtrack.api;
 
-// @checkstyle AvoidStaticImport (2 lines)
+// @checkstyle AvoidStaticImport (3 lines)
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Random;
+
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.hamcrest.core.IsEqual;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.llorllale.youtrack.api.session.Login;
@@ -89,6 +93,40 @@ public final class DefaultProjectsIT {
       new DefaultProjects(null, login, HttpClients::createDefault)
         .get(String.valueOf(new Random(System.currentTimeMillis()).nextInt()))
         .isPresent()
+    );
+  }
+
+  /**
+   * {@link DefaultProjects} should create the project with the given parameters, and this
+   * new project should be present in the stream of projects.
+   * @throws Exception unexpected
+   * @since 1.1.0
+   */
+  @Test
+  public void createProject() throws Exception {
+    final String id = "DPIT";
+    final String name = "DefaultProjectsIT";
+    final User leader = new DefaultYouTrack(login)
+      .projects()
+      .get(config.youtrackTestProjectId()).get()
+      .users()
+      .user(config.youtrackUser());
+    final Projects projects = new DefaultProjects(
+      new DefaultYouTrack(login),
+      login,
+      () -> HttpClientBuilder.create().build()
+    );
+    final Project project = projects.create(id, name, leader);
+    assertThat(
+      project.id(),
+      new IsEqual<>(id)
+    );
+    assertThat(
+      project.name(),
+      new IsEqual<>(name)
+    );
+    assertTrue(
+      projects.stream().anyMatch(p -> project.id().equals(p.id()))
     );
   }
 }

--- a/src/test/java/org/llorllale/youtrack/api/IntegrationTestsConfig.java
+++ b/src/test/java/org/llorllale/youtrack/api/IntegrationTestsConfig.java
@@ -91,7 +91,7 @@ public final class IntegrationTestsConfig {
   }
 
   /**
-   * The ID of the pre-created YouTrack project.
+   * The ID of the pre-created YouTrack project with timetracking enabled.
    * @return the pre-configured project's id
    * @since 0.3.0
    */


### PR DESCRIPTION
This PR closes #243:
* Adds new `Projects.create()` method
* `DefaultProjectTimeTrackingIT` and `DefaultIssueTimeTrackingIT` now explicitly use the pre-configured project because that one has timetracking enabled